### PR TITLE
refactor: worker: use mongo instead of svix to find event types

### DIFF
--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -13,5 +13,6 @@ type Store interface {
 	DeleteOneConfig(ctx context.Context, id string) (int64, error)
 	UpdateOneConfigActive(ctx context.Context, id string, active bool) (model.ConfigInserted, int64, error)
 	UpdateOneConfigSecret(ctx context.Context, id, secret string) (int64, error)
+	FindEventType(ctx context.Context, eventType string) (bool, error)
 	Close(ctx context.Context) error
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -306,15 +306,6 @@ func TestWorker(t *testing.T) {
 		require.NoError(t, conn.Close())
 	}()
 
-	eventType := "TYPE"
-	endpoint := "https://example.com"
-	cfg := model.Config{
-		Endpoint:   endpoint,
-		Secret:     model.NewSecret(),
-		EventTypes: []string{eventType},
-	}
-	require.NoError(t, cfg.Validate())
-
 	t.Run("clean existing configs", func(t *testing.T) {
 		resp, err := http.Get(serverBaseURL + server.PathConfigs)
 		require.NoError(t, err)
@@ -328,6 +319,15 @@ func TestWorker(t *testing.T) {
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		}
 	})
+
+	eventType := "TYPE_TO_SEND"
+	endpoint := "https://example.com"
+	cfg := model.Config{
+		Endpoint:   endpoint,
+		Secret:     model.NewSecret(),
+		EventTypes: []string{"OTHER_TYPE", eventType},
+	}
+	require.NoError(t, cfg.Validate())
 
 	var insertedId string
 
@@ -346,6 +346,7 @@ func TestWorker(t *testing.T) {
 	for i := 0; i < n; i++ {
 		messages = append(messages, newEventMessage(t, eventType, i))
 	}
+	messages = append(messages, newEventMessage(t, "TYPE_NOT_TO_SEND", n))
 	nbBytes, err := conn.WriteMessages(messages...)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, nbBytes)


### PR DESCRIPTION
# refactor: worker: use mongo instead of svix to find event types

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Technical debt
