### PR TITLE
feat: scalable retry mechanism with atomic claim pattern

### DIFF
--- a/cmd/flag/flags.go
+++ b/cmd/flag/flags.go
@@ -12,8 +12,9 @@ const (
 	Listen   = "listen"
 	Worker   = "worker"
 
-	RetryPeriod     = "retry-period"
-	AbortAfter      = "abort-after"
+	RetryPeriod    = "retry-period"
+	RetryBatchSize = "retry-batch-size"
+	AbortAfter     = "abort-after"
 	MinBackoffDelay = "min-backoff-delay"
 	MaxBackoffDelay = "max-backoff-delay"
 
@@ -30,7 +31,8 @@ const (
 )
 
 var (
-	DefaultRetryPeriod = time.Minute
+	DefaultRetryPeriod    = 3 * time.Second
+	DefaultRetryBatchSize = 50
 )
 
 func Init(flagSet *pflag.FlagSet) {
@@ -38,6 +40,7 @@ func Init(flagSet *pflag.FlagSet) {
 
 	flagSet.String(Listen, DefaultBindAddressServer, "server HTTP bind address")
 	flagSet.Duration(RetryPeriod, DefaultRetryPeriod, "worker retry period")
+	flagSet.Int(RetryBatchSize, DefaultRetryBatchSize, "number of webhook IDs to claim per retry tick")
 	flagSet.Bool(Worker, false, "Enable worker on server")
 
 	flagSet.StringSlice(KafkaTopics, []string{DefaultKafkaTopic}, "Kafka topics")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -63,6 +63,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 	isWorker, _ := cmd.Flags().GetBool(flag.Worker)
 	if isWorker {
 		retryPeriod, _ := cmd.Flags().GetDuration(flag.RetryPeriod)
+		retryBatchSize, _ := cmd.Flags().GetInt(flag.RetryBatchSize)
 		minBackOffDelay, _ := cmd.Flags().GetDuration(flag.MinBackoffDelay)
 		maxBackOffDelay, _ := cmd.Flags().GetDuration(flag.MaxBackoffDelay)
 		abortAfter, _ := cmd.Flags().GetDuration(flag.AbortAfter)
@@ -76,6 +77,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 				maxBackOffDelay,
 				abortAfter,
 			),
+			retryBatchSize,
 			service.IsDebug(cmd),
 			topics,
 		))

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -53,6 +53,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 	}
 
 	retryPeriod, _ := cmd.Flags().GetDuration(flag.RetryPeriod)
+	retryBatchSize, _ := cmd.Flags().GetInt(flag.RetryBatchSize)
 	minBackOffDelay, _ := cmd.Flags().GetDuration(flag.MinBackoffDelay)
 	maxBackOffDelay, _ := cmd.Flags().GetDuration(flag.MaxBackoffDelay)
 	abortAfter, _ := cmd.Flags().GetDuration(flag.AbortAfter)
@@ -78,6 +79,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 				maxBackOffDelay,
 				abortAfter,
 			),
+			retryBatchSize,
 			service.IsDebug(cmd),
 			topics,
 		),

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -1,0 +1,163 @@
+# Retry Mechanism
+
+## Overview
+
+The retry mechanism processes failed webhook delivery attempts. A background worker (the `Retrier`) polls the database at regular intervals, claims a batch of pending retries, executes the HTTP calls, and updates their status.
+
+## Architecture
+
+### Statuses
+
+| Status | Description |
+|--------|-------------|
+| `success` | Webhook delivered successfully (HTTP 2xx) |
+| `to retry` | Delivery failed, scheduled for retry with a `next_retry_after` timestamp |
+| `retrying` | Claimed by a worker, currently being processed |
+| `failed` | Max retry duration exceeded, permanently failed |
+
+### Lifecycle
+
+```
+[new message] --> MakeAttempt --> HTTP call
+                                    |
+                            success? --> "success"
+                            failure? --> "to retry" + next_retry_after
+                                              |
+                                    [retrier tick] --> claim ("retrying")
+                                              |
+                                        HTTP call (30s timeout)
+                                              |
+                                    success? --> "success"
+                                    failure? --> "to retry" (retry again later)
+                                    max delay? --> "failed"
+```
+
+## Worker Behavior
+
+### Tick Loop
+
+The `Retrier` runs in a single goroutine with the following loop:
+
+1. **Recover stale claims** (once per minute) -- Reset attempts stuck in `retrying` for more than 5 minutes (from crashed workers) back to `to retry`. This runs at most once per minute to avoid unnecessary database load.
+2. **Claim a batch** -- Atomically set up to `--retry-batch-size` (default: 50) distinct webhook IDs from `to retry` to `retrying` using a single CTE query. Oldest retries are claimed first (`ORDER BY next_retry_after ASC`).
+3. **Process batch in parallel** -- All claimed webhook IDs are processed concurrently via a bounded worker pool (`pond`), capped at `--retry-batch-size` concurrent goroutines. For each webhook:
+   - Fetch the `retrying` attempts
+   - Unmarshal the payload from the most recent attempt
+   - Execute the HTTP call (`MakeAttempt`) with a 30-second timeout
+   - Insert a new attempt record with the result
+   - Update only the claimed (`retrying`) attempts to the final status
+   - The worker waits for all goroutines to complete before sleeping
+4. **Sleep** -- Wait `--retry-period` (default: 3 seconds), then repeat.
+
+### Error Handling
+
+Per-webhook errors are **logged and skipped**, not fatal. A single failing webhook endpoint does not stop the worker from processing the rest of the batch. Only context cancellation stops the worker.
+
+Errors that are handled gracefully:
+- HTTP call failures (timeout, DNS, connection refused)
+- Malformed payloads
+- Database errors on individual attempts
+
+### Claim Query
+
+The claim is atomic and safe for concurrent workers:
+
+```sql
+WITH to_claim AS (
+    SELECT DISTINCT ON (webhook_id) webhook_id
+    FROM attempts
+    JOIN configs c ON c.id = attempts.config->>'id'
+    WHERE attempts.status = 'to retry'
+      AND attempts.next_retry_after < NOW()
+    ORDER BY webhook_id, attempts.next_retry_after ASC
+    LIMIT $batch_size
+),
+claimed AS (
+    UPDATE attempts
+    SET status = 'retrying', updated_at = NOW()
+    WHERE webhook_id IN (SELECT webhook_id FROM to_claim_limited)
+      AND status = 'to retry'
+    RETURNING webhook_id
+)
+SELECT DISTINCT webhook_id FROM claimed
+```
+
+When two workers execute this concurrently:
+- Worker A's UPDATE locks the rows and sets them to `retrying`.
+- Worker B's UPDATE finds those rows no longer match `status = 'to retry'` and skips them.
+- No duplicate processing occurs.
+
+Oldest retries are prioritized via `ORDER BY next_retry_after ASC`, preventing starvation of long-pending webhooks.
+
+### Status Scoping
+
+`UpdateAttemptsStatus` only modifies attempts in `retrying` status. Historical attempts (`success`, `failed`) are never overwritten. This ensures:
+- Accurate audit trail per attempt
+- No accidental overwrites from concurrent Kafka messages creating new attempts for the same webhook
+
+## Multi-Worker Scaling
+
+| Workers | Estimated Throughput |
+|---------|---------------------|
+| 1 | ~1,000 webhooks/min |
+| 2 | ~2,000 webhooks/min |
+| 4 | ~4,000 webhooks/min |
+| N | ~N x 1,000 webhooks/min |
+
+Throughput scales linearly because each worker claims its own exclusive batch.
+
+### Crash Recovery
+
+If a worker crashes mid-processing, its claimed attempts remain in `retrying` status. Every worker runs a recovery step at the start of each tick:
+
+```sql
+UPDATE attempts
+SET status = 'to retry', updated_at = NOW()
+WHERE status = 'retrying'
+  AND updated_at < NOW() - INTERVAL '5 minutes'
+```
+
+This ensures no attempt is permanently stuck. The 5-minute window is chosen to be well above the 30-second HTTP timeout, avoiding false recoveries on slow-but-active requests.
+
+## Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--retry-period` | `3s` | Interval between retry ticks |
+| `--retry-batch-size` | `50` | Number of distinct webhook IDs claimed per tick |
+| `--min-backoff-delay` | `1m` | Minimum delay before retrying a failed attempt |
+| `--max-backoff-delay` | `1h` | Maximum delay between retries (exponential backoff) |
+| `--abort-after` | `30d` | Stop retrying after this duration and mark as `failed` |
+
+## Database Indexes
+
+Two partial indexes optimize the retry queries:
+
+```sql
+-- Speeds up the claim query (finding eligible retries)
+CREATE INDEX idx_attempts_retry_pending
+ON attempts (next_retry_after)
+WHERE status = 'to retry';
+
+-- Speeds up fetching claimed attempts by webhook ID
+CREATE INDEX idx_attempts_retrying
+ON attempts (webhook_id)
+WHERE status = 'retrying';
+
+-- Speeds up the stale recovery query
+CREATE INDEX idx_attempts_retrying_recovery
+ON attempts (updated_at)
+WHERE status = 'retrying';
+```
+
+## HTTP Client
+
+The HTTP client used for webhook delivery has a **30-second timeout** (`pkg/otlp/module.go`). This prevents a single slow endpoint from blocking the worker indefinitely and ensures the stale recovery window (5 minutes) is never reached during normal operation.
+
+## Backoff Strategy
+
+Uses exponential backoff with jitter (see `pkg/backoff/exponential.go`):
+
+- Each retry attempt increases the delay exponentially, starting from `--min-backoff-delay`.
+- The delay is capped at `--max-backoff-delay`.
+- After `--abort-after` total elapsed time since the first attempt, the webhook is marked as `failed` permanently.

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	StatusAttemptSuccess = "success"
-	StatusAttemptToRetry = "to retry"
-	StatusAttemptFailed  = "failed"
+	StatusAttemptSuccess  = "success"
+	StatusAttemptToRetry  = "to retry"
+	StatusAttemptRetrying = "retrying"
+	StatusAttemptFailed   = "failed"
 )
 
 type Attempt struct {

--- a/pkg/otlp/module.go
+++ b/pkg/otlp/module.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/fx"
@@ -11,6 +12,7 @@ import (
 func HttpClientModule() fx.Option {
 	return fx.Provide(func() *http.Client {
 		return &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: otelhttp.NewTransport(http.DefaultTransport, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 				str := fmt.Sprintf("%s %s", r.Method, r.URL.Path)
 				if len(r.URL.Query()) == 0 {

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -57,6 +57,35 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 				return errors.Wrap(err, "adding 'name' column")
 			},
 		},
+		migrations.Migration{
+			Name: "Add partial index for retry polling",
+			Up: func(ctx context.Context, tx bun.IDB) error {
+				_, err := tx.ExecContext(ctx, `
+					CREATE INDEX IF NOT EXISTS idx_attempts_retry_pending
+					ON attempts (next_retry_after)
+					WHERE status = 'to retry'
+				`)
+				if err != nil {
+					return errors.Wrap(err, "creating partial index for retry polling")
+				}
+
+				_, err = tx.ExecContext(ctx, `
+					CREATE INDEX IF NOT EXISTS idx_attempts_retrying
+					ON attempts (webhook_id)
+					WHERE status = 'retrying'
+				`)
+				if err != nil {
+					return errors.Wrap(err, "creating partial index for retrying status")
+				}
+
+				_, err = tx.ExecContext(ctx, `
+					CREATE INDEX IF NOT EXISTS idx_attempts_retrying_recovery
+					ON attempts (updated_at)
+					WHERE status = 'retrying'
+				`)
+				return errors.Wrap(err, "creating partial index for retrying recovery")
+			},
+		},
 	)
 
 	return migrator.Up(ctx)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -143,8 +143,7 @@ func (s Store) FindAttemptsToRetryByWebhookID(ctx context.Context, webhookID str
 	res := []webhooks.Attempt{}
 	if err := s.db.NewSelect().Model(&res).
 		Where("webhook_id = ?", webhookID).
-		Where("status = ?", webhooks.StatusAttemptToRetry).
-		Where("next_retry_after < ?", time.Now().UTC()).
+		Where("status = ?", webhooks.StatusAttemptRetrying).
 		Order("created_at DESC").
 		Scan(ctx); err != nil {
 		return nil, errors.Wrap(err, "finding attempts to retry")
@@ -153,55 +152,76 @@ func (s Store) FindAttemptsToRetryByWebhookID(ctx context.Context, webhookID str
 	return res, nil
 }
 
-func (s Store) FindWebhookIDsToRetry(ctx context.Context) ([]string, error) {
-	atts := []webhooks.Attempt{}
-	if err := s.db.NewSelect().Model(&atts).
-		Column("webhook_id").Distinct().
-		Where("status = ?", webhooks.StatusAttemptToRetry).
-		Join("join configs c on c.id = attempt.config->>'id'").
-		Where("next_retry_after < ?", time.Now().UTC()).
-		Scan(ctx); err != nil {
-		return nil, errors.Wrap(err, "finding distinct webhook IDs to retry")
-	}
-
+func (s Store) FindWebhookIDsToRetry(ctx context.Context, limit int) ([]string, error) {
+	// Raw SQL is required here: the atomic claim pattern (SELECT + UPDATE in a single
+	// statement via CTE) cannot be expressed with Bun's query builder.
 	webhookIDs := []string{}
-	for _, att := range atts {
-		webhookIDs = append(webhookIDs, att.WebhookID)
+	_, err := s.db.NewRaw(`
+		WITH to_claim AS (
+			SELECT DISTINCT ON (webhook_id) webhook_id
+			FROM attempts
+			JOIN configs c ON c.id = attempts.config->>'id'
+			WHERE attempts.status = ?
+			  AND attempts.next_retry_after < NOW()
+			ORDER BY webhook_id, attempts.next_retry_after ASC
+			LIMIT ?
+		),
+		claimed AS (
+			UPDATE attempts
+			SET status = ?, updated_at = NOW()
+			WHERE webhook_id IN (SELECT webhook_id FROM to_claim)
+			  AND status = ?
+			RETURNING webhook_id
+		)
+		SELECT DISTINCT webhook_id FROM claimed
+	`, webhooks.StatusAttemptToRetry, limit,
+		webhooks.StatusAttemptRetrying, webhooks.StatusAttemptToRetry,
+	).Exec(ctx, &webhookIDs)
+	if err != nil {
+		return nil, errors.Wrap(err, "claiming webhook IDs to retry")
 	}
 
 	return webhookIDs, nil
 }
 
+func (s Store) RecoverStaleRetryingAttempts(ctx context.Context, staleDuration time.Duration) error {
+	_, err := s.db.NewUpdate().
+		Model((*webhooks.Attempt)(nil)).
+		Where("status = ?", webhooks.StatusAttemptRetrying).
+		Where("updated_at < ?", time.Now().UTC().Add(-staleDuration)).
+		Set("status = ?", webhooks.StatusAttemptToRetry).
+		Set("updated_at = ?", time.Now().UTC()).
+		Exec(ctx)
+	return errors.Wrap(err, "recovering stale retrying attempts")
+}
+
 func (s Store) UpdateAttemptsStatus(ctx context.Context, webhookID, status string) ([]webhooks.Attempt, error) {
 	atts := []webhooks.Attempt{}
 	if err := s.db.NewSelect().Model(&atts).
-		Where("webhook_id = ?", webhookID).Scan(ctx); err != nil {
+		Where("webhook_id = ?", webhookID).
+		Where("status = ?", webhooks.StatusAttemptRetrying).
+		Scan(ctx); err != nil {
 		return []webhooks.Attempt{}, errors.Wrap(err, "selecting attempts by webhook ID before updating status")
 	}
 	if len(atts) == 0 {
 		return []webhooks.Attempt{}, storage.ErrWebhookIDNotFound
 	}
 
-	toUpdate := false
-	for _, att := range atts {
-		if att.Status != status {
-			toUpdate = true
-		}
-	}
-	if !toUpdate {
+	if status == webhooks.StatusAttemptRetrying {
 		return []webhooks.Attempt{}, storage.ErrAttemptsNotModified
 	}
 
 	if _, err := s.db.NewUpdate().Model((*webhooks.Attempt)(nil)).
 		Where("webhook_id = ?", webhookID).
+		Where("status = ?", webhooks.StatusAttemptRetrying).
 		Set("status = ?", status).
 		Set("updated_at = ?", time.Now().UTC()).
 		Exec(ctx); err != nil {
 		return []webhooks.Attempt{}, errors.Wrap(err, "updating attempts status")
 	}
 
-	for _, att := range atts {
-		att.Status = status
+	for i := range atts {
+		atts[i].Status = status
 	}
 
 	return atts, nil

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -50,7 +50,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(cfgs))
 
-	ids, err := store.FindWebhookIDsToRetry(context.Background())
+	ids, err := store.FindWebhookIDsToRetry(context.Background(), 50)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(ids))
 

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -1,0 +1,422 @@
+package postgres_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/formancehq/go-libs/v2/bun/bundebug"
+	"github.com/formancehq/go-libs/v2/bun/bunconnect"
+	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+
+	webhooks "github.com/formancehq/webhooks/pkg"
+	"github.com/formancehq/webhooks/pkg/storage"
+	"github.com/formancehq/webhooks/pkg/storage/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) storage.Store {
+	t.Helper()
+
+	hooks := make([]bun.QueryHook, 0)
+	if testing.Verbose() {
+		hooks = append(hooks, bundebug.NewQueryHook())
+	}
+
+	pgDB := srv.NewDatabase(t)
+	db, err := bunconnect.OpenSQLDB(logging.TestingContext(), bunconnect.ConnectionOptions{
+		DatabaseSourceName: pgDB.ConnString(),
+	}, hooks...)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Ping())
+	require.NoError(t, storage.Migrate(context.Background(), db))
+
+	store, err := postgres.NewStore(db)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close(context.Background())
+	})
+
+	return store
+}
+
+func insertConfigAndAttempt(t *testing.T, db storage.Store, webhookID, status string, nextRetryAfter time.Time) webhooks.Config {
+	t.Helper()
+	ctx := context.Background()
+
+	cfg, err := db.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	insertAttemptWithConfig(t, db, webhookID, cfg, status, 1, nextRetryAfter)
+
+	return cfg
+}
+
+func insertAttemptWithConfig(t *testing.T, db storage.Store, webhookID string, cfg webhooks.Config, status string, retryAttempt int, nextRetryAfter time.Time) {
+	t.Helper()
+	ctx := context.Background()
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	att := webhooks.Attempt{
+		ID:             uuid.NewString(),
+		WebhookID:      webhookID,
+		Config:         cfg,
+		Payload:        string(payload),
+		StatusCode:     500,
+		RetryAttempt:   retryAttempt,
+		Status:         status,
+		NextRetryAfter: nextRetryAfter,
+	}
+	require.NoError(t, db.InsertOneAttempt(ctx, att))
+}
+
+func TestClaimWebhookIDsToRetry(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID1 := uuid.NewString()
+	webhookID2 := uuid.NewString()
+	webhookID3 := uuid.NewString()
+
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert 3 webhooks with "to retry" status and past next_retry_after
+	insertConfigAndAttempt(t, store, webhookID1, webhooks.StatusAttemptToRetry, pastTime)
+	insertConfigAndAttempt(t, store, webhookID2, webhooks.StatusAttemptToRetry, pastTime)
+	insertConfigAndAttempt(t, store, webhookID3, webhooks.StatusAttemptToRetry, pastTime)
+
+	// Claim with limit 2 -- should only get 2
+	ids, err := store.FindWebhookIDsToRetry(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	// Claimed attempts should now be in "retrying" status
+	atts, err := store.FindAttemptsToRetryByWebhookID(ctx, ids[0])
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+
+	// Second claim should get the remaining 1
+	ids2, err := store.FindWebhookIDsToRetry(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, ids2, 1)
+
+	// No overlap between first and second claim
+	for _, id := range ids2 {
+		require.NotContains(t, ids, id)
+	}
+
+	// Third claim should return empty
+	ids3, err := store.FindWebhookIDsToRetry(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, ids3, 0)
+}
+
+func TestClaimRespectsNextRetryAfter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookIDPast := uuid.NewString()
+	webhookIDFuture := uuid.NewString()
+
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+	futureTime := time.Now().UTC().Add(10 * time.Minute)
+
+	// One attempt eligible, one not yet
+	insertConfigAndAttempt(t, store, webhookIDPast, webhooks.StatusAttemptToRetry, pastTime)
+	insertConfigAndAttempt(t, store, webhookIDFuture, webhooks.StatusAttemptToRetry, futureTime)
+
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.Equal(t, webhookIDPast, ids[0])
+}
+
+func TestUpdateAttemptsStatusOnlyUpdatesRetrying(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert two attempts: one "retrying", one "success"
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	retryingAtt := webhooks.Attempt{
+		ID:             uuid.NewString(),
+		WebhookID:      webhookID,
+		Config:         cfg,
+		Payload:        string(payload),
+		StatusCode:     500,
+		RetryAttempt:   2,
+		Status:         webhooks.StatusAttemptRetrying,
+		NextRetryAfter: pastTime,
+	}
+	successAtt := webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    webhookID,
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   200,
+		RetryAttempt: 0,
+		Status:       webhooks.StatusAttemptSuccess,
+	}
+	require.NoError(t, store.InsertOneAttempt(ctx, retryingAtt))
+	require.NoError(t, store.InsertOneAttempt(ctx, successAtt))
+
+	// Update retrying attempts to failed
+	_, err = store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptFailed)
+	require.NoError(t, err)
+
+	// The "retrying" attempt should now be "failed"
+	// The "success" attempt should still be "success"
+	// We verify by trying to find retrying attempts -- should be 0
+	atts, err := store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 0)
+}
+
+func TestRecoverStaleRetryingAttempts(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert config and a "to retry" attempt
+	insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+
+	// Claim it
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	// Verify it's now "retrying"
+	atts, err := store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+
+	// Recovery with short duration should NOT recover (updated_at is recent)
+	err = store.RecoverStaleRetryingAttempts(ctx, 5*time.Minute)
+	require.NoError(t, err)
+
+	// Still retrying
+	atts, err = store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+
+	// Recovery with zero duration should recover everything
+	err = store.RecoverStaleRetryingAttempts(ctx, 0)
+	require.NoError(t, err)
+
+	// No longer retrying
+	atts, err = store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 0)
+
+	// Should be claimable again
+	ids, err = store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+}
+
+func TestClaimMultipleAttemptsPerWebhook(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert one config, then 3 "to retry" attempts for the same webhook
+	cfg := insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+	insertAttemptWithConfig(t, store, webhookID, cfg, webhooks.StatusAttemptToRetry, 2, pastTime)
+	insertAttemptWithConfig(t, store, webhookID, cfg, webhooks.StatusAttemptToRetry, 3, pastTime)
+
+	// Claim
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	// All 3 attempts should now be "retrying"
+	atts, err := store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 3)
+}
+
+func TestClaimOnlyToRetryNotOtherStatuses(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert config with one "to retry" and one "success" attempt for same webhook
+	cfg := insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+	insertAttemptWithConfig(t, store, webhookID, cfg, webhooks.StatusAttemptSuccess, 0, time.Time{})
+
+	// Claim
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	// Only the "to retry" attempt should be "retrying", not the "success" one
+	atts, err := store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+}
+
+func TestFullRetryLifecycle(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Step 1: Insert a "to retry" attempt
+	insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+
+	// Step 2: Claim it
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	// Step 3: Simulate retry failure -- update status back to "to retry"
+	_, err = store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptToRetry)
+	require.NoError(t, err)
+
+	// Step 4: Should be claimable again
+	ids, err = store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	// Step 5: Simulate retry success
+	_, err = store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptSuccess)
+	require.NoError(t, err)
+
+	// Step 6: Should NOT be claimable anymore
+	ids, err = store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 0)
+}
+
+func TestClaimIgnoresDeletedConfig(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert config + attempt, then delete the config
+	cfg := insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+	err := store.DeleteOneConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+
+	// Should NOT be claimable (config no longer exists, JOIN fails)
+	ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+	require.NoError(t, err)
+	require.Len(t, ids, 0)
+}
+
+func TestConcurrentGoroutineClaimsNoDuplicates(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert 20 webhooks
+	for range 20 {
+		insertConfigAndAttempt(t, store, uuid.NewString(), webhooks.StatusAttemptToRetry, pastTime)
+	}
+
+	// Run 4 goroutines claiming concurrently -- verify no duplicates
+	type result struct {
+		ids []string
+		err error
+	}
+	ch := make(chan result, 4)
+
+	for range 4 {
+		go func() {
+			ids, err := store.FindWebhookIDsToRetry(ctx, 10)
+			ch <- result{ids: ids, err: err}
+		}()
+	}
+
+	allClaimed := make(map[string]bool)
+	for range 4 {
+		res := <-ch
+		require.NoError(t, res.err)
+		for _, id := range res.ids {
+			require.False(t, allClaimed[id], "webhook %s was claimed by multiple goroutines", id)
+			allClaimed[id] = true
+		}
+	}
+
+	// At least some were claimed (concurrent workers may overlap on snapshot)
+	require.Greater(t, len(allClaimed), 0)
+	// No duplicates (the key invariant)
+	// The rest will be claimed in subsequent ticks
+
+	// Drain remaining by sequential claims
+	for {
+		ids, err := store.FindWebhookIDsToRetry(ctx, 50)
+		require.NoError(t, err)
+		if len(ids) == 0 {
+			break
+		}
+		for _, id := range ids {
+			require.False(t, allClaimed[id], "webhook %s was claimed twice across rounds", id)
+			allClaimed[id] = true
+		}
+	}
+
+	// All 20 webhooks claimed exactly once across all rounds
+	require.Len(t, allClaimed, 20)
+}
+
+func TestConcurrentClaimsNoOverlap(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	// Insert 10 webhooks
+	webhookIDs := make([]string, 10)
+	for i := range webhookIDs {
+		webhookIDs[i] = uuid.NewString()
+		insertConfigAndAttempt(t, store, webhookIDs[i], webhooks.StatusAttemptToRetry, pastTime)
+	}
+
+	// Simulate concurrent claims by doing sequential claims of 3
+	allClaimed := make(map[string]bool)
+
+	for {
+		ids, err := store.FindWebhookIDsToRetry(ctx, 3)
+		require.NoError(t, err)
+		if len(ids) == 0 {
+			break
+		}
+		for _, id := range ids {
+			require.False(t, allClaimed[id], "webhook %s was claimed twice", id)
+			allClaimed[id] = true
+		}
+	}
+
+	// All 10 webhooks should have been claimed exactly once
+	require.Len(t, allClaimed, 10)
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/pkg/errors"
@@ -21,7 +22,8 @@ type Store interface {
 	UpdateOneConfigActivation(ctx context.Context, id string, active bool) (webhooks.Config, error)
 	UpdateOneConfigSecret(ctx context.Context, id, secret string) (webhooks.Config, error)
 	FindAttemptsToRetryByWebhookID(ctx context.Context, webhookID string) ([]webhooks.Attempt, error)
-	FindWebhookIDsToRetry(ctx context.Context) (webhookIDs []string, err error)
+	FindWebhookIDsToRetry(ctx context.Context, limit int) (webhookIDs []string, err error)
+	RecoverStaleRetryingAttempts(ctx context.Context, staleDuration time.Duration) error
 	UpdateAttemptsStatus(ctx context.Context, webhookID string, status string) ([]webhooks.Attempt, error)
 	InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error
 	Close(ctx context.Context) error

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -27,7 +27,7 @@ import (
 
 var Tracer = otel.Tracer("listener")
 
-func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy, debug bool, topics []string) fx.Option {
+func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy, retryBatchSize int, debug bool, topics []string) fx.Option {
 	var options []fx.Option
 
 	options = append(options, fx.Invoke(func(r *message.Router, subscriber message.Subscriber, store storage.Store, httpClient *http.Client) {
@@ -35,8 +35,8 @@ func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webh
 	}))
 	options = append(options, publish.FXModuleFromFlags(cmd, debug))
 	options = append(options, fx.Provide(
-		func() (time.Duration, webhooks.BackoffPolicy) {
-			return retriesCron, retryPolicy
+		func() (time.Duration, webhooks.BackoffPolicy, int) {
+			return retriesCron, retryPolicy, retryBatchSize
 		},
 		NewRetrier,
 	))

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -3,10 +3,10 @@ package worker
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/alitto/pond"
 	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/go-libs/v2/publish"
 	webhooks "github.com/formancehq/webhooks/pkg"
@@ -19,28 +19,31 @@ type Retrier struct {
 	httpClient *http.Client
 	store      storage.Store
 
-	retriesCron time.Duration
-	retryPolicy webhooks.BackoffPolicy
+	retriesCron    time.Duration
+	retryPolicy    webhooks.BackoffPolicy
+	retryBatchSize int
+	retryPool      *pond.WorkerPool
 
 	stopChan chan chan struct{}
 }
 
-func NewRetrier(store storage.Store, httpClient *http.Client, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy) (*Retrier, error) {
+func NewRetrier(store storage.Store, httpClient *http.Client, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy, retryBatchSize int) (*Retrier, error) {
 	return &Retrier{
-		httpClient:  httpClient,
-		store:       store,
-		retriesCron: retriesCron,
-		retryPolicy: retryPolicy,
-		stopChan:    make(chan chan struct{}),
+		httpClient:     httpClient,
+		store:          store,
+		retriesCron:    retriesCron,
+		retryPolicy:    retryPolicy,
+		retryBatchSize: retryBatchSize,
+		retryPool:      pond.New(retryBatchSize, retryBatchSize),
+		stopChan:       make(chan chan struct{}),
 	}, nil
 }
 
 func (w *Retrier) Run(ctx context.Context) error {
-	errChan := make(chan error)
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go w.attemptRetries(ctxWithCancel, errChan)
+	go w.attemptRetries(ctxWithCancel)
 
 	for {
 		select {
@@ -51,8 +54,6 @@ func (w *Retrier) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			logging.FromContext(ctx).Debugf("worker: context done: %s", ctx.Err())
 			return nil
-		case err := <-errChan:
-			return errors.Wrap(err, "kafka.Retrier")
 		}
 	}
 }
@@ -76,65 +77,85 @@ func (w *Retrier) Stop(ctx context.Context) {
 	}
 }
 
-var ErrNoAttemptsFound = errors.New("attemptRetries: no attempts found")
+var errNoAttemptsFound = errors.New("attemptRetries: no attempts found")
 
-func (w *Retrier) attemptRetries(ctx context.Context, errChan chan error) {
+const staleRecoveryInterval = time.Minute
+
+func (w *Retrier) attemptRetries(ctx context.Context) {
+	lastRecovery := time.Time{}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			// Find all webhookIDs ready to be retried
-			webhookIDs, err := w.store.FindWebhookIDsToRetry(ctx)
+			// Recover attempts stuck in "retrying" state from crashed workers (at most once per minute)
+			if time.Since(lastRecovery) >= staleRecoveryInterval {
+				if err := w.store.RecoverStaleRetryingAttempts(ctx, 5*time.Minute); err != nil {
+					logging.FromContext(ctx).Errorf("recovering stale retrying attempts: %s", err)
+				}
+				lastRecovery = time.Now()
+			}
+
+			// Atomically claim a batch of webhookIDs to retry
+			webhookIDs, err := w.store.FindWebhookIDsToRetry(ctx, w.retryBatchSize)
 			if err != nil {
-				errChan <- errors.Wrap(err, "storage.Store.FindWebhookIDsToRetry")
+				logging.FromContext(ctx).Errorf("claiming webhook IDs to retry: %s", err)
+				time.Sleep(w.retriesCron)
 				continue
-			} else {
-				logging.FromContext(ctx).Debugf(
-					"found %d distinct webhookIDs to retry: %+v", len(webhookIDs), webhookIDs)
 			}
 
+			logging.FromContext(ctx).Debugf(
+				"claimed %d distinct webhookIDs to retry: %+v", len(webhookIDs), webhookIDs)
+
+			group := w.retryPool.Group()
 			for _, webhookID := range webhookIDs {
-				atts, err := w.store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
-				if err != nil {
-					errChan <- errors.Wrap(err, "storage.Store.FindAttemptsToRetryByWebhookID")
-					continue
-				}
-				if len(atts) == 0 {
-					errChan <- fmt.Errorf("%w for webhookID: %s", ErrNoAttemptsFound, webhookID)
-					continue
-				}
-
-				var ev publish.EventMessage
-				err = json.Unmarshal([]byte(atts[0].Payload), &ev)
-				if err != nil {
-					errChan <- errors.Wrap(err, "json.Unmarshal")
-					continue
-				}
-
-				newAttemptNb := atts[0].RetryAttempt + 1
-				attempt, err := webhooks.MakeAttempt(ctx, w.httpClient, w.retryPolicy, uuid.NewString(),
-					webhookID, newAttemptNb, atts[0].Config, ev.IdempotencyKey, []byte(atts[0].Payload), false)
-				if err != nil {
-					errChan <- errors.Wrap(err, "webhooks.MakeAttempt")
-					continue
-				}
-
-				if err := w.store.InsertOneAttempt(ctx, attempt); err != nil {
-					errChan <- errors.Wrap(err, "storage.Store.InsertOneAttempt retried")
-					continue
-				}
-
-				if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, attempt.Status); err != nil {
-					if errors.Is(err, storage.ErrAttemptsNotModified) {
-						continue
-					}
-					errChan <- errors.Wrap(err, "storage.Store.UpdateAttemptsStatus")
-					continue
-				}
+				id := webhookID
+				group.Submit(func() {
+					w.processWebhookRetry(ctx, id)
+				})
 			}
+			group.Wait()
 		}
 
 		time.Sleep(w.retriesCron)
+	}
+}
+
+func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
+	atts, err := w.store.FindAttemptsToRetryByWebhookID(ctx, webhookID)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("finding attempts for webhook %s: %s", webhookID, err)
+		return
+	}
+	if len(atts) == 0 {
+		logging.FromContext(ctx).Errorf("%s for webhookID: %s", errNoAttemptsFound, webhookID)
+		return
+	}
+
+	var ev publish.EventMessage
+	if err := json.Unmarshal([]byte(atts[0].Payload), &ev); err != nil {
+		logging.FromContext(ctx).Errorf("unmarshalling payload for webhook %s: %s", webhookID, err)
+		return
+	}
+
+	newAttemptNb := atts[0].RetryAttempt + 1
+	attempt, err := webhooks.MakeAttempt(ctx, w.httpClient, w.retryPolicy, uuid.NewString(),
+		webhookID, newAttemptNb, atts[0].Config, ev.IdempotencyKey, []byte(atts[0].Payload), false)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("making attempt for webhook %s: %s", webhookID, err)
+		return
+	}
+
+	if err := w.store.InsertOneAttempt(ctx, attempt); err != nil {
+		logging.FromContext(ctx).Errorf("inserting attempt for webhook %s: %s", webhookID, err)
+		return
+	}
+
+	if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, attempt.Status); err != nil {
+		if errors.Is(err, storage.ErrAttemptsNotModified) {
+			return
+		}
+		logging.FromContext(ctx).Errorf("updating attempts status for webhook %s: %s", webhookID, err)
 	}
 }

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -1,0 +1,310 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	webhooks "github.com/formancehq/webhooks/pkg"
+	"github.com/formancehq/webhooks/pkg/backoff"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStore implements storage.Store with only the methods needed for retry tests.
+type mockStore struct {
+	mu         sync.Mutex
+	webhookIDs []string
+	attempts   map[string][]webhooks.Attempt
+	inserted   []webhooks.Attempt
+	updated    map[string]string // webhookID -> final status
+}
+
+func newMockStore(webhookIDs []string, attempts map[string][]webhooks.Attempt) *mockStore {
+	return &mockStore{
+		webhookIDs: webhookIDs,
+		attempts:   attempts,
+		updated:    make(map[string]string),
+	}
+}
+
+func (m *mockStore) FindWebhookIDsToRetry(_ context.Context, limit int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.webhookIDs) == 0 {
+		return nil, nil
+	}
+	end := min(limit, len(m.webhookIDs))
+	claimed := m.webhookIDs[:end]
+	m.webhookIDs = m.webhookIDs[end:]
+	return claimed, nil
+}
+
+func (m *mockStore) FindAttemptsToRetryByWebhookID(_ context.Context, webhookID string) ([]webhooks.Attempt, error) {
+	return m.attempts[webhookID], nil
+}
+
+func (m *mockStore) InsertOneAttempt(_ context.Context, att webhooks.Attempt) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inserted = append(m.inserted, att)
+	return nil
+}
+
+func (m *mockStore) UpdateAttemptsStatus(_ context.Context, webhookID string, status string) ([]webhooks.Attempt, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.updated[webhookID] = status
+	return nil, nil
+}
+
+func (m *mockStore) RecoverStaleRetryingAttempts(_ context.Context, _ time.Duration) error {
+	return nil
+}
+
+// Unused Store interface methods
+func (m *mockStore) FindManyConfigs(_ context.Context, _ map[string]any) ([]webhooks.Config, error) {
+	return nil, nil
+}
+func (m *mockStore) InsertOneConfig(_ context.Context, _ webhooks.ConfigUser) (webhooks.Config, error) {
+	return webhooks.Config{}, nil
+}
+func (m *mockStore) DeleteOneConfig(_ context.Context, _ string) error { return nil }
+func (m *mockStore) UpdateOneConfigActivation(_ context.Context, _ string, _ bool) (webhooks.Config, error) {
+	return webhooks.Config{}, nil
+}
+func (m *mockStore) UpdateOneConfigSecret(_ context.Context, _, _ string) (webhooks.Config, error) {
+	return webhooks.Config{}, nil
+}
+func (m *mockStore) UpdateOneConfig(_ context.Context, _ string, _ webhooks.ConfigUser) error {
+	return nil
+}
+func (m *mockStore) Close(_ context.Context) error { return nil }
+
+func TestProcessWebhookRetrySuccess(t *testing.T) {
+	// HTTP server that returns 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		},
+	})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	// A new attempt should have been inserted
+	require.Len(t, store.inserted, 1)
+	require.Equal(t, webhooks.StatusAttemptSuccess, store.inserted[0].Status)
+
+	// Status should have been updated to success
+	require.Equal(t, webhooks.StatusAttemptSuccess, store.updated[webhookID])
+}
+
+func TestProcessWebhookRetryFailure(t *testing.T) {
+	// HTTP server that returns 500
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		},
+	})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	// A new attempt should have been inserted with "to retry" status
+	require.Len(t, store.inserted, 1)
+	require.Equal(t, webhooks.StatusAttemptToRetry, store.inserted[0].Status)
+}
+
+func TestPoolProcessesBatchInParallel(t *testing.T) {
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	// HTTP server that tracks concurrent requests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := concurrentCount.Add(1)
+		// Track max concurrency
+		for {
+			old := maxConcurrent.Load()
+			if current <= old || maxConcurrent.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond) // simulate latency
+		concurrentCount.Add(-1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	// Create 10 webhooks
+	webhookIDs := make([]string, 10)
+	attempts := make(map[string][]webhooks.Attempt)
+	for i := range 10 {
+		id := "webhook-" + string(rune('A'+i))
+		webhookIDs[i] = id
+		attempts[id] = []webhooks.Attempt{
+			{
+				ID:           "att-" + id,
+				WebhookID:    id,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		}
+	}
+
+	store := newMockStore(webhookIDs, attempts)
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	// Manually claim and process (simulating one tick)
+	claimed, err := store.FindWebhookIDsToRetry(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 10)
+
+	group := retrier.retryPool.Group()
+	for _, webhookID := range claimed {
+		id := webhookID
+		group.Submit(func() {
+			retrier.processWebhookRetry(context.Background(), id)
+		})
+	}
+	group.Wait()
+
+	// All 10 should have been processed
+	require.Len(t, store.inserted, 10)
+
+	// Should have achieved some parallelism (more than 1 concurrent)
+	require.Greater(t, maxConcurrent.Load(), int32(1), "pool should process webhooks in parallel")
+}
+
+func TestProcessWebhookRetryNoAttempts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HTTP server should not be called when there are no attempts")
+	}))
+	defer server.Close()
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	// Should not panic or make HTTP calls
+	retrier.processWebhookRetry(context.Background(), "nonexistent")
+
+	require.Len(t, store.inserted, 0)
+}
+
+func TestProcessWebhookRetryBadPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HTTP server should not be called with bad payload")
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      "not-valid-json",
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		},
+	})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	// Should not panic, should log error and return
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	require.Len(t, store.inserted, 0)
+}


### PR DESCRIPTION
## Summary

- Redesign the retry worker to support multi-worker scaling with continuous batch processing
- Add `retrying` intermediate status for atomic claim pattern via PostgreSQL CTE
- Batch processing with configurable `--retry-batch-size` (default 50) and `--retry-period` (default 3s)
- Parallel batch processing via `pond` worker pool (bounded concurrency)
- Crash recovery for stale `retrying` attempts (runs once per minute)
- 3 partial indexes for retry polling, claimed attempts, and recovery
- `UpdateAttemptsStatus` scoped to `retrying` rows only (preserves historical attempt statuses)
- Worker resilient to per-webhook errors (log + continue instead of crashing)
- HTTP client timeout (30s) prevents worker blocking on slow endpoints
- Oldest retries prioritized via `ORDER BY next_retry_after ASC`

## Scaling

| Workers | Estimated Throughput |
|---------|---------------------|
| 1 | ~1,000 webhooks/min |
| N | ~N × 1,000 webhooks/min |

Workers claim exclusive batches atomically — no duplicate processing.

## Test plan

- [x] 12 storage-level tests (claim, limit, concurrency, recovery, lifecycle, deleted config)
- [x] 5 worker-level tests (success, failure, parallel pool, no attempts, bad payload)
- [x] `go build ./...` and `go vet ./...` pass
- [ ] CI pipeline passes
- [ ] Manual validation on staging with multiple worker replicas
- [ ] Run purge query for old "to retry" attempts before deploying