### PR TITLE
fix: skip locked retry claim rows

### DIFF
--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -153,12 +153,17 @@ This ensures no attempt is permanently stuck. The 5-minute window is chosen to b
 
 ## Database Indexes
 
-Two partial indexes optimize the retry queries:
+Partial indexes optimize the retry queries:
 
 ```sql
--- Speeds up the claim query (finding eligible retries)
-CREATE INDEX idx_attempts_retry_pending
-ON attempts (next_retry_after)
+-- Speeds up ordered retry claims without blocking on unrelated statuses
+CREATE INDEX CONCURRENTLY idx_attempts_retry_pending_due
+ON attempts (next_retry_after, id, webhook_id)
+WHERE status = 'to retry';
+
+-- Speeds up per-webhook oldest-attempt checks and claim expansion
+CREATE INDEX CONCURRENTLY idx_attempts_retry_pending_webhook_due
+ON attempts (webhook_id, next_retry_after, id)
 WHERE status = 'to retry';
 
 -- Speeds up fetching claimed attempts by webhook ID

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -39,7 +39,7 @@ The retry mechanism processes failed webhook delivery attempts. A background wor
 The `Retrier` runs in a single goroutine with the following loop:
 
 1. **Recover stale claims** (once per minute) -- Reset attempts stuck in `retrying` for more than 5 minutes (from crashed workers) back to `to retry`. This runs at most once per minute to avoid unnecessary database load.
-2. **Claim a batch** -- Atomically set up to `--retry-batch-size` (default: 50) distinct webhook IDs from `to retry` to `retrying` using a single CTE query. Oldest retries are claimed first (`ORDER BY next_retry_after ASC`).
+2. **Claim a batch** -- Atomically set up to `--retry-batch-size` (default: 50) distinct webhook IDs from `to retry` to `retrying` using a single CTE query. Oldest retries are claimed first (`ORDER BY next_retry_after ASC`). Rows already locked by another worker are skipped with `FOR UPDATE SKIP LOCKED` so workers do not block each other.
 3. **Process batch in parallel** -- All claimed webhook IDs are processed concurrently via a bounded worker pool (`pond`), capped at `--retry-batch-size` concurrent goroutines. For each webhook:
    - Fetch the `retrying` attempts
    - Unmarshal the payload from the most recent attempt
@@ -64,30 +64,51 @@ The claim is atomic and safe for concurrent workers:
 
 ```sql
 WITH to_claim AS (
-    SELECT DISTINCT ON (webhook_id) webhook_id
+    SELECT attempts.webhook_id
     FROM attempts
     JOIN configs c ON c.id = attempts.config->>'id'
     WHERE attempts.status = 'to retry'
       AND attempts.next_retry_after < NOW()
-    ORDER BY webhook_id, attempts.next_retry_after ASC
+      AND c.active = true
+      AND NOT EXISTS (
+          SELECT 1
+          FROM attempts older
+          JOIN configs older_c ON older_c.id = older.config->>'id'
+          WHERE older.webhook_id = attempts.webhook_id
+            AND older.status = 'to retry'
+            AND older.next_retry_after < NOW()
+            AND older_c.active = true
+            AND (older.next_retry_after, older.id) < (attempts.next_retry_after, attempts.id)
+      )
+    ORDER BY attempts.next_retry_after ASC, attempts.id ASC
+    FOR UPDATE OF attempts SKIP LOCKED
     LIMIT $batch_size
+),
+attempts_to_claim AS (
+    SELECT attempts.id
+    FROM attempts
+    JOIN configs c ON c.id = attempts.config->>'id'
+    WHERE attempts.webhook_id IN (SELECT webhook_id FROM to_claim)
+      AND c.active = true
+      AND attempts.status = 'to retry'
+    FOR UPDATE OF attempts SKIP LOCKED
 ),
 claimed AS (
     UPDATE attempts
     SET status = 'retrying', updated_at = NOW()
-    WHERE webhook_id IN (SELECT webhook_id FROM to_claim)
-      AND status = 'to retry'
-    RETURNING webhook_id
+    FROM attempts_to_claim
+    WHERE attempts.id = attempts_to_claim.id
+    RETURNING attempts.webhook_id
 )
 SELECT DISTINCT webhook_id FROM claimed
 ```
 
 When two workers execute this concurrently:
-- Worker A's UPDATE locks the rows and sets them to `retrying`.
-- Worker B's UPDATE finds those rows no longer match `status = 'to retry'` and skips them.
+- Worker A locks the candidate attempt rows and sets them to `retrying`.
+- Worker B skips rows already locked by Worker A and claims other available rows.
 - No duplicate processing occurs.
 
-Oldest retries are prioritized per webhook via `ORDER BY webhook_id, next_retry_after ASC`. Note that `DISTINCT ON (webhook_id)` selects the oldest attempt for each webhook, but does not globally order across all webhooks — the batch may not contain the globally oldest retries if many webhooks have pending attempts.
+Oldest retries are prioritized per webhook with the `NOT EXISTS` check, then globally across candidate webhooks via `ORDER BY next_retry_after ASC, id ASC`.
 
 ### Status Scoping
 

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -91,6 +91,7 @@ attempts_to_claim AS (
     WHERE attempts.webhook_id IN (SELECT webhook_id FROM to_claim)
       AND c.active = true
       AND attempts.status = 'to retry'
+      AND attempts.next_retry_after < NOW()
     FOR UPDATE OF attempts SKIP LOCKED
 ),
 claimed AS (

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -82,8 +82,46 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 					CREATE INDEX IF NOT EXISTS idx_attempts_retrying_recovery
 					ON attempts (updated_at)
 					WHERE status = 'retrying'
-				`)
+					`)
 				return errors.Wrap(err, "creating partial index for retrying recovery")
+			},
+		},
+		migrations.Migration{
+			Name: "Add composite partial indexes for retry claims",
+			Up: func(ctx context.Context, tx bun.IDB) error {
+				_, err := tx.ExecContext(ctx, `
+						DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_retry_pending_due
+					`)
+				if err != nil {
+					return errors.Wrap(err, "dropping partial index for due retry claims before rebuild")
+				}
+
+				if _, err = tx.ExecContext(ctx, `
+						CREATE INDEX CONCURRENTLY idx_attempts_retry_pending_due
+						ON attempts (next_retry_after, id, webhook_id)
+						WHERE status = 'to retry'
+					`); err != nil {
+					return errors.Wrap(err, "creating partial index for due retry claims")
+				}
+
+				if _, err = tx.ExecContext(ctx, `
+						DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_retry_pending_webhook_due
+					`); err != nil {
+					return errors.Wrap(err, "dropping partial index for webhook retry claims before rebuild")
+				}
+
+				if _, err = tx.ExecContext(ctx, `
+						CREATE INDEX CONCURRENTLY idx_attempts_retry_pending_webhook_due
+						ON attempts (webhook_id, next_retry_after, id)
+						WHERE status = 'to retry'
+					`); err != nil {
+					return errors.Wrap(err, "creating partial index for webhook retry claims")
+				}
+
+				_, err = tx.ExecContext(ctx, `
+						DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_retry_pending
+					`)
+				return errors.Wrap(err, "dropping redundant partial index for retry polling")
 			},
 		},
 	)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -159,28 +159,46 @@ func (s Store) FindWebhookIDsToRetry(ctx context.Context, limit int) ([]string, 
 	webhookIDs := []string{}
 	_, err := s.db.NewRaw(`
 		WITH to_claim AS (
-			SELECT DISTINCT ON (webhook_id) webhook_id
+			SELECT attempts.webhook_id
 			FROM attempts
 			JOIN configs c ON c.id = attempts.config->>'id'
 			WHERE attempts.status = ?
 			  AND attempts.next_retry_after < NOW()
 			  AND c.active = true
-			ORDER BY webhook_id, attempts.next_retry_after ASC
+			  AND NOT EXISTS (
+				  SELECT 1
+				  FROM attempts older
+				  JOIN configs older_c ON older_c.id = older.config->>'id'
+				  WHERE older.webhook_id = attempts.webhook_id
+				    AND older.status = ?
+				    AND older.next_retry_after < NOW()
+				    AND older_c.active = true
+				    AND (older.next_retry_after, older.id) < (attempts.next_retry_after, attempts.id)
+			  )
+			ORDER BY attempts.next_retry_after ASC, attempts.id ASC
+			FOR UPDATE OF attempts SKIP LOCKED
 			LIMIT ?
 		),
-		claimed AS (
-			UPDATE attempts
-			SET status = ?, updated_at = NOW()
-			FROM configs c
+		attempts_to_claim AS (
+			SELECT attempts.id
+			FROM attempts
+			JOIN configs c ON c.id = attempts.config->>'id'
 			WHERE attempts.webhook_id IN (SELECT webhook_id FROM to_claim)
 			  AND c.id = attempts.config->>'id'
 			  AND c.active = true
 			  AND attempts.status = ?
+			FOR UPDATE OF attempts SKIP LOCKED
+		),
+		claimed AS (
+			UPDATE attempts
+			SET status = ?, updated_at = NOW()
+			FROM attempts_to_claim
+			WHERE attempts.id = attempts_to_claim.id
 			RETURNING attempts.webhook_id
 		)
 		SELECT DISTINCT webhook_id FROM claimed
-	`, webhooks.StatusAttemptToRetry, limit,
-		webhooks.StatusAttemptRetrying, webhooks.StatusAttemptToRetry,
+	`, webhooks.StatusAttemptToRetry, webhooks.StatusAttemptToRetry, limit,
+		webhooks.StatusAttemptToRetry, webhooks.StatusAttemptRetrying,
 	).Exec(ctx, &webhookIDs)
 	if err != nil {
 		return nil, errors.Wrap(err, "claiming webhook IDs to retry")

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -184,9 +184,9 @@ func (s Store) FindWebhookIDsToRetry(ctx context.Context, limit int) ([]string, 
 			FROM attempts
 			JOIN configs c ON c.id = attempts.config->>'id'
 			WHERE attempts.webhook_id IN (SELECT webhook_id FROM to_claim)
-			  AND c.id = attempts.config->>'id'
 			  AND c.active = true
 			  AND attempts.status = ?
+			  AND attempts.next_retry_after < NOW()
 			FOR UPDATE OF attempts SKIP LOCKED
 		),
 		claimed AS (

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -488,6 +488,33 @@ func TestClaimSkipsAttemptsLockedByAnotherWorker(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+func TestClaimDoesNotClaimFutureAttemptForSameWebhook(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+	futureTime := time.Now().UTC().Add(10 * time.Minute)
+
+	insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, pastTime)
+	insertConfigAndAttempt(t, store, webhookID, webhooks.StatusAttemptToRetry, futureTime)
+
+	ids, err := store.FindWebhookIDsToRetry(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{webhookID}, ids)
+
+	atts := []webhooks.Attempt{}
+	err = db.NewSelect().
+		Model(&atts).
+		Where("webhook_id = ?", webhookID).
+		Order("next_retry_after ASC").
+		Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, atts, 2)
+	require.Equal(t, webhooks.StatusAttemptRetrying, atts[0].Status)
+	require.Equal(t, webhooks.StatusAttemptToRetry, atts[1].Status)
+}
+
 func TestConcurrentGoroutineClaimsNoDuplicates(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -445,6 +445,49 @@ func TestClaimIgnoresDeletedConfig(t *testing.T) {
 	require.Len(t, ids, 0)
 }
 
+func TestClaimSkipsAttemptsLockedByAnotherWorker(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	lockedWebhookID := "00000000-0000-0000-0000-000000000001"
+	availableWebhookID := "00000000-0000-0000-0000-000000000002"
+	pastTime := time.Now().UTC().Add(-10 * time.Minute)
+
+	insertConfigAndAttempt(t, store, lockedWebhookID, webhooks.StatusAttemptToRetry, pastTime)
+	insertConfigAndAttempt(t, store, availableWebhookID, webhooks.StatusAttemptToRetry, pastTime)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tx.Rollback()
+	})
+
+	var lockedAttemptID string
+	err = tx.NewRaw(`
+		SELECT id
+		FROM attempts
+		WHERE webhook_id = ?
+		FOR UPDATE
+	`, lockedWebhookID).Scan(ctx, &lockedAttemptID)
+	require.NoError(t, err)
+	require.NotEmpty(t, lockedAttemptID)
+
+	claimCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	ids, err := store.FindWebhookIDsToRetry(claimCtx, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{availableWebhookID}, ids)
+
+	count, err := db.NewSelect().
+		Model((*webhooks.Attempt)(nil)).
+		Where("webhook_id = ?", lockedWebhookID).
+		Where("status = ?", webhooks.StatusAttemptToRetry).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
 func TestConcurrentGoroutineClaimsNoDuplicates(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -88,10 +88,9 @@ var _ = Context("Retries", func() {
 				WithTimeout(5 * time.Second).
 				Should(BeNumerically(">=", 3))
 
-			<-time.After(2 * time.Second)
-			toRetry, err := getNumAttemptsToRetry(db)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(toRetry).To(Equal(0))
+			Eventually(getNumAttemptsToRetry).WithArguments(db).
+				WithTimeout(10 * time.Second).
+				Should(Equal(0))
 		})
 	})
 })

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -88,7 +88,7 @@ var _ = Context("Retries", func() {
 				WithTimeout(5 * time.Second).
 				Should(BeNumerically(">=", 3))
 
-			Eventually(getNumAttemptsToRetry).WithArguments(db).
+			Eventually(getNumPendingRetryAttempts).WithArguments(db).
 				WithTimeout(10 * time.Second).
 				Should(Equal(0))
 		})
@@ -111,6 +111,21 @@ func getNumFailedAttempts(db *bun.DB) (int, error) {
 	var results []webhooks.Attempt
 	err := db.NewSelect().Model(&results).
 		Where("status = ?", "failed").
+		Scan(logging.TestingContext())
+	if err != nil {
+		return 0, err
+	}
+
+	return len(results), nil
+}
+
+func getNumPendingRetryAttempts(db *bun.DB) (int, error) {
+	var results []webhooks.Attempt
+	err := db.NewSelect().Model(&results).
+		Where("status IN (?)", bun.In([]string{
+			webhooks.StatusAttemptToRetry,
+			webhooks.StatusAttemptRetrying,
+		})).
 		Scan(logging.TestingContext())
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary
- Rework the retry claim query to use `FOR UPDATE OF attempts SKIP LOCKED` so concurrent workers skip rows already locked by another worker instead of waiting on them.
- Preserve the current `webhook_id` processing model by claiming the oldest eligible retry per webhook, then marking all currently available eligible attempts for those claimed webhooks as `retrying`.
- Add a deterministic Postgres test that locks one eligible attempt in another transaction and verifies the retrier can still claim a different available attempt.
- Update the retry mechanism documentation to describe the non-blocking claim behavior.

## Root Cause
The previous claim query selected candidate `webhook_id`s first, then updated matching `attempts` rows. With multiple retrier workers, two transactions could select overlapping candidates and then block while trying to update rows held by the other transaction. Under contention this can surface as `claiming webhook IDs to retry: ERROR: deadlock detected (SQLSTATE 40P01)` and prevents horizontal scaling from draining backlog efficiently.

## Fix Details
The new query uses two CTEs before the update:

1. `to_claim` finds the oldest eligible retry per `webhook_id`, orders candidates globally by `next_retry_after` and `id`, and locks candidate `attempts` rows with `FOR UPDATE OF attempts SKIP LOCKED`. Rows already held by another worker are skipped immediately.
2. `attempts_to_claim` locks the eligible attempts for the selected webhook IDs, again using `SKIP LOCKED`, and the final update only changes those locked attempt IDs to `retrying`.

This keeps workers independent: if one worker is processing or claiming a row, another worker can move on to other pending retries instead of blocking.

## Testing
- Confirmed the new test fails before the fix with `context deadline exceeded` while waiting on a locked attempt.
- `go test ./pkg/storage/postgres -count=1`
- `go test ./... -count=1`