### PR TITLE
fix(openapi)!: remove name from ConfigUser request schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -531,9 +531,6 @@ components:
         - endpoint
         - eventTypes
       properties:
-        name:
-          type: string
-          example: customer_payment
         endpoint:
           type: string
           example: https://example.com

--- a/pkg/client/.speakeasy/gen.lock
+++ b/pkg/client/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 32d27b3c-3111-406b-93c0-0ff757cb4a42
 management:
-  docChecksum: deb59848ebba788b4be2035471cf417e
+  docChecksum: fbd5b7c3eb2d482d3974a74b8cde2c48
   docVersion: WEBHOOKS_VERSION
   speakeasyVersion: 1.351.0
   generationVersion: 2.384.1
-  releaseVersion: 0.3.4
-  configChecksum: 603594beeecac405f8c5b830b6e90ba2
+  releaseVersion: 0.3.5
+  configChecksum: 61de82bcb19502a493b6c7b5cfee047d
 features:
   go:
     additionalDependencies: 0.1.0

--- a/pkg/client/.speakeasy/gen.yaml
+++ b/pkg/client/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 go:
-  version: 0.3.4
+  version: 0.3.5
   additionalDependencies: {}
   allowUnknownFieldsInWeakUnions: false
   clientServerStatusCodesAsErrors: true

--- a/pkg/client/docs/models/components/configuser.md
+++ b/pkg/client/docs/models/components/configuser.md
@@ -5,7 +5,6 @@
 
 | Field                            | Type                             | Required                         | Description                      | Example                          |
 | -------------------------------- | -------------------------------- | -------------------------------- | -------------------------------- | -------------------------------- |
-| `Name`                           | **string*                        | :heavy_minus_sign:               | N/A                              | customer_payment                 |
 | `Endpoint`                       | *string*                         | :heavy_check_mark:               | N/A                              | https://example.com              |
 | `Secret`                         | **string*                        | :heavy_minus_sign:               | N/A                              | V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3 |
 | `EventTypes`                     | []*string*                       | :heavy_check_mark:               | N/A                              | [<br/>"TYPE1",<br/>"TYPE2"<br/>] |

--- a/pkg/client/docs/sdks/v1/README.md
+++ b/pkg/client/docs/sdks/v1/README.md
@@ -106,7 +106,6 @@ func main() {
         }),
     )
     request := components.ConfigUser{
-        Name: client.String("customer_payment"),
         Endpoint: "https://example.com",
         Secret: client.String("V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3"),
         EventTypes: []string{
@@ -224,7 +223,6 @@ func main() {
     request := operations.UpdateConfigRequest{
         ID: "4997257d-dfb6-445b-929c-cbe2ab182818",
         ConfigUser: components.ConfigUser{
-            Name: client.String("customer_payment"),
             Endpoint: "https://example.com",
             Secret: client.String("V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3"),
             EventTypes: []string{

--- a/pkg/client/formance.go
+++ b/pkg/client/formance.go
@@ -143,9 +143,9 @@ func New(opts ...SDKOption) *Formance {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "WEBHOOKS_VERSION",
-			SDKVersion:        "0.3.4",
+			SDKVersion:        "0.3.5",
 			GenVersion:        "2.384.1",
-			UserAgent:         "speakeasy-sdk/go 0.3.4 2.384.1 WEBHOOKS_VERSION github.com/formancehq/webhooks/pkg/client",
+			UserAgent:         "speakeasy-sdk/go 0.3.5 2.384.1 WEBHOOKS_VERSION github.com/formancehq/webhooks/pkg/client",
 			Hooks:             hooks.New(),
 		},
 	}

--- a/pkg/client/go.mod
+++ b/pkg/client/go.mod
@@ -1,10 +1,8 @@
-
 module github.com/formancehq/webhooks/pkg/client
 
 go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
-    github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05
-    github.com/spyzhov/ajson v0.8.0
+	github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05
 )

--- a/pkg/client/go.sum
+++ b/pkg/client/go.sum
@@ -1,3 +1,4 @@
+github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05 h1:S92OBrGuLLZsyM5ybUzgc/mPjIYk2AZqufieooe98uw=
 github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05/go.mod h1:M9R1FoZ3y//hwwnJtO51ypFGwm8ZfpxPT/ZLtO1mcgQ=
-github.com/spyzhov/ajson v0.8.0/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=

--- a/pkg/client/models/components/configuser.go
+++ b/pkg/client/models/components/configuser.go
@@ -3,17 +3,9 @@
 package components
 
 type ConfigUser struct {
-	Name       *string  `json:"name,omitempty"`
 	Endpoint   string   `json:"endpoint"`
 	Secret     *string  `json:"secret,omitempty"`
 	EventTypes []string `json:"eventTypes"`
-}
-
-func (o *ConfigUser) GetName() *string {
-	if o == nil {
-		return nil
-	}
-	return o.Name
 }
 
 func (o *ConfigUser) GetEndpoint() string {


### PR DESCRIPTION
## Summary

- Remove the unsupported `name` property from the `ConfigUser` request schema.
- Regenerate the Go SDK from the current `main` branch, preserving the delivery and replay APIs added by #163.
- Tidy the nested client module so its dependency metadata is complete and reproducible.

## Why

The server-side `webhooks.ConfigUser` only accepts `endpoint`, `secret`, and `eventTypes`. Request decoding uses `json.Decoder.DisallowUnknownFields()`, so clients generated from the previous OpenAPI contract could send `name` and receive a `400 VALIDATION` response.

The database and response model still contain a legacy name field, but no request path has ever populated it. Supporting named configurations would require a separate feature change covering the server request model, persistence behavior, and response schema.

## Breaking change

`pkg/client/models/components.ConfigUser.Name` and `GetName()` are removed. The field was already rejected at runtime by the server.

## Validation

- `nix develop --impure --command just pre-commit`
- `go test ./...` from `pkg/client`
- `nix develop --impure --command just tests` (race detector, integration tags, PostgreSQL/NATS, and e2e suite)

## Follow-up

The unused database column can be removed separately if named configurations are not planned.