### PR TITLE
feat: add webhook delivery circuit breaker

### DIFF
--- a/docs/adr/0001-webhook-delivery-circuit-breaker.md
+++ b/docs/adr/0001-webhook-delivery-circuit-breaker.md
@@ -75,7 +75,7 @@ Persist circuit state separately from webhook configuration. A dedicated table i
 
 ```text
 webhook_delivery_circuits
-  config_id primary key
+  config_id text primary key references configs(id)
   state
   consecutive_failures
   window_started_at

--- a/docs/adr/0001-webhook-delivery-circuit-breaker.md
+++ b/docs/adr/0001-webhook-delivery-circuit-breaker.md
@@ -1,0 +1,151 @@
+# ADR 0001: Reduce webhook retry amplification with delivery circuit breakers
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-09
+
+## Context
+
+The webhook worker currently consumes events from Kafka or NATS, finds matching active webhook configs, performs the HTTP delivery synchronously, and persists each delivery attempt in PostgreSQL. Failed attempts are stored with a `next_retry_after` timestamp. A background retrier then polls PostgreSQL, claims due attempts, performs the HTTP call again, inserts a new attempt, and updates the previously claimed attempts.
+
+This works for isolated failures, but it becomes expensive when a recipient endpoint is unhealthy for an extended period.
+
+For example, if a customer endpoint starts returning errors for every request while events continue to arrive, every event/config pair creates its own retry chain. PostgreSQL then becomes both the audit store and the retry scheduler for a large number of attempts that are very likely to fail for the same root cause. This is retry amplification: the system treats many correlated failures as independent work.
+
+Moving retry delays to the broker helps with scheduling cost, but it does not solve retry amplification by itself. If an endpoint is known to be unhealthy, requeueing every failed delivery still creates a large amount of useless work. It also needs different implementations for NATS and Kafka:
+
+- NATS JetStream supports delayed redelivery primitives such as delayed negative acknowledgement.
+- Kafka does not currently provide a stable, portable "deliver this message after X" primitive in the broker. A Kafka-compatible implementation usually needs retry topics, a `not_before` timestamp, and a consumer that promotes due messages back to the delivery topic.
+
+We need a design that reduces PostgreSQL load during endpoint outages while remaining compatible with both Kafka and NATS.
+
+## Decision
+
+Introduce a delivery circuit breaker per webhook config.
+
+The circuit breaker is separate from the user-controlled `configs.active` flag:
+
+- `configs.active` means the user wants this webhook subscription enabled.
+- The circuit state means the platform currently considers delivery to this config healthy, unhealthy, or under recovery test.
+
+The circuit has three states:
+
+| State | Meaning | Behavior |
+| --- | --- | --- |
+| `closed` | Normal healthy state | Deliver events and retry failed deliveries normally. |
+| `open` | Endpoint is considered unhealthy | Stop regular deliveries and regular retries for this config. Schedule only sparse recovery probes. |
+| `half_open` | Recovery test in progress | Allow a small bounded number of probe deliveries. Close on success, reopen on failure. |
+
+When the circuit is `closed`, delivery failures update health counters for the config. The circuit opens when configured thresholds are reached, for example:
+
+- N consecutive retryable failures.
+- A high retryable failure ratio over a rolling time window with a minimum request volume.
+- Repeated timeout or network failures.
+
+When the circuit is `open`:
+
+- New events for this config are not delivered immediately.
+- Due retries for this config are not delivered immediately.
+- The system does not create one retry chain per event while the endpoint is known to be unhealthy.
+- A recovery probe is scheduled with backoff, for example after 5 minutes, then 15 minutes, then 1 hour.
+
+When the probe is due, the circuit moves to `half_open`. A successful probe closes the circuit and resets the failure counters. A failed probe reopens the circuit and increases the probe delay.
+
+The circuit breaker should gate both initial deliveries and retries before any HTTP request is made. Existing active/inactive config checks still apply: inactive configs must not receive normal deliveries or probes.
+
+## Delivery retry scheduling
+
+Add a delivery retry scheduler abstraction for individual webhook delivery commands. This abstraction must schedule a specific webhook delivery, not the original source event. Retrying the original event would redeliver webhooks that may already have succeeded.
+
+The scheduler interface should hide broker-specific behavior:
+
+- NATS adapter: use JetStream delayed redelivery or delayed republish where available.
+- Kafka adapter: use retry topics and a `not_before` timestamp. A retry topic consumer promotes messages back to the delivery topic only when due.
+- Existing PostgreSQL retrier can remain as a transitional adapter during migration.
+
+The circuit breaker is still required even if retry scheduling moves to the broker. Broker-delayed retry reduces scheduler load; the circuit breaker reduces useless retry work while an endpoint is unhealthy.
+
+## Persistence model
+
+Persist circuit state separately from webhook configuration. A dedicated table is preferable to overloading `configs`, for example:
+
+```text
+webhook_delivery_circuits
+  config_id primary key
+  state
+  consecutive_failures
+  window_started_at
+  window_successes
+  window_failures
+  opened_until
+  probe_attempt
+  last_failure_at
+  last_failure_status_code
+  last_failure_reason
+  updated_at
+```
+
+Delivery attempts remain the audit trail for real HTTP calls. The system should avoid inserting one full attempt row per suppressed event while a circuit is open unless product requirements explicitly require per-event audit. Prefer lightweight aggregate counters or metrics for suppressed deliveries, for example "suppressed 12,430 deliveries for config X while circuit was open".
+
+## Consequences
+
+Positive consequences:
+
+- Caps retry work for a broken endpoint.
+- Reduces PostgreSQL load during correlated endpoint outages.
+- Makes endpoint health explicit and observable.
+- Keeps user intent (`active`) separate from platform protection (`circuit_state`).
+- Works with either the current PostgreSQL retrier or future NATS/Kafka retry adapters.
+
+Negative consequences:
+
+- Some deliveries may be skipped or delayed while the circuit is open, depending on the selected backlog policy.
+- The system needs new state, thresholds, metrics, and operational tooling.
+- False positives are possible if thresholds are too aggressive.
+- Product behavior must be explicit when a circuit opens: suppress, buffer for replay, or use a hybrid policy.
+
+## Open questions
+
+1. What should happen to new events while the circuit is open?
+   - Suppress/drop with lightweight audit.
+   - Buffer for replay when the endpoint recovers.
+   - Hybrid policy, such as buffer for a bounded time or bounded count, then suppress.
+
+2. Should the circuit be keyed by webhook config ID, endpoint URL, customer, or a combination?
+
+3. Which failures are retryable and circuit-breaking?
+   - Timeouts and network errors should count.
+   - 5xx and 429 should likely count.
+   - 4xx responses may need separate classification because some are permanent configuration errors.
+
+4. How should users be notified when a circuit opens or closes?
+
+5. Should the API expose circuit status separately from config activation?
+
+6. What are the default thresholds and probe backoff values?
+
+## Rollout plan
+
+1. Add circuit state persistence and observability while keeping the existing PostgreSQL retrier.
+2. Gate initial deliveries and PostgreSQL retries on circuit state.
+3. Add suppression or bounded backlog behavior for events received while the circuit is open.
+4. Add NATS and Kafka delivery retry scheduler adapters behind a common interface.
+5. Gradually move retry scheduling out of PostgreSQL once behavior and metrics are validated.
+
+## Alternatives considered
+
+### Move retries directly to the broker
+
+This reduces PostgreSQL scheduler pressure, but it does not prevent retry amplification. A broken endpoint would still receive one retry chain per event unless a circuit breaker or equivalent health gate exists.
+
+### Disable the webhook config automatically
+
+Automatically setting `configs.active = false` would reduce work, but it conflates user intent with platform protection. A separate circuit state allows the webhook to remain user-enabled while the platform temporarily suppresses delivery attempts.
+
+### Keep the current PostgreSQL retry loop and tune indexes
+
+The current retry loop can be optimized, but it still uses PostgreSQL as a scheduler for many attempts that are correlated by the same unhealthy endpoint. This does not address the underlying amplification pattern.

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -14,6 +14,22 @@ The retry mechanism processes failed webhook delivery attempts. A background wor
 | `to retry` | Delivery failed, scheduled for retry with a `next_retry_after` timestamp |
 | `retrying` | Claimed by a worker, currently being processed |
 | `failed` | Max retry duration exceeded, permanently failed |
+| `suppressed` | Retry was claimed but not delivered because the webhook circuit is open |
+
+### Delivery Circuit Breaker
+
+Retries are gated by a delivery circuit breaker per webhook config. The circuit is separate from config activation:
+
+- `configs.active` means the user wants the webhook enabled.
+- Circuit state means the platform currently considers delivery healthy enough to attempt.
+
+The circuit starts `closed`. Retryable failures increment a consecutive failure counter. After 10 consecutive failures, the circuit opens for 5 minutes. While open:
+
+- New events for that config are skipped without creating per-event delivery attempts.
+- Claimed retry attempts are marked `suppressed` instead of performing another HTTP call.
+- When the open window expires, one worker may move the circuit to `half_open` and perform a probe delivery.
+
+A successful probe closes the circuit and resets counters. A failed probe reopens it with exponential probe backoff, capped at 1 hour.
 
 ### Lifecycle
 
@@ -30,6 +46,7 @@ The retry mechanism processes failed webhook delivery attempts. A background wor
                                     success? --> "success"
                                     failure? --> "to retry" (retry again later)
                                     max delay? --> "failed"
+                                    circuit open? --> "suppressed"
 ```
 
 ## Worker Behavior
@@ -42,6 +59,8 @@ The `Retrier` runs in a single goroutine with the following loop:
 2. **Claim a batch** -- Atomically set up to `--retry-batch-size` (default: 50) distinct webhook IDs from `to retry` to `retrying` using a single CTE query. Oldest retries are claimed first (`ORDER BY next_retry_after ASC`). Rows already locked by another worker are skipped with `FOR UPDATE SKIP LOCKED` so workers do not block each other.
 3. **Process batch in parallel** -- All claimed webhook IDs are processed concurrently via a bounded worker pool (`pond`), capped at `--retry-batch-size` concurrent goroutines. For each webhook:
    - Fetch the `retrying` attempts
+   - Check the delivery circuit for the attempt config
+   - Mark claimed attempts as `suppressed` without HTTP delivery if the circuit is open
    - Unmarshal the payload from the most recent attempt
    - Execute the HTTP call (`MakeAttempt`) with a 30-second timeout
    - Insert a new attempt record with the result

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	StatusAttemptSuccess  = "success"
-	StatusAttemptToRetry  = "to retry"
-	StatusAttemptRetrying = "retrying"
-	StatusAttemptFailed   = "failed"
+	StatusAttemptSuccess    = "success"
+	StatusAttemptToRetry    = "to retry"
+	StatusAttemptRetrying   = "retrying"
+	StatusAttemptFailed     = "failed"
+	StatusAttemptSuppressed = "suppressed"
 )
 
 type Attempt struct {

--- a/pkg/circuit.go
+++ b/pkg/circuit.go
@@ -1,0 +1,77 @@
+package webhooks
+
+import (
+	"context"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	CircuitStateClosed   = "closed"
+	CircuitStateOpen     = "open"
+	CircuitStateHalfOpen = "half_open"
+
+	CircuitDecisionReasonClosed        = "closed"
+	CircuitDecisionReasonOpenUntil     = "open_until"
+	CircuitDecisionReasonHalfOpenProbe = "half_open_probe"
+	CircuitDecisionReasonProbeBusy     = "half_open_probe_busy"
+)
+
+const (
+	DefaultCircuitFailureThreshold = 10
+	DefaultCircuitOpenDelay        = 5 * time.Minute
+	DefaultCircuitMaxOpenDelay     = time.Hour
+)
+
+type DeliveryCircuit struct {
+	bun.BaseModel `bun:"table:webhook_delivery_circuits"`
+
+	ConfigID              string    `json:"configID" bun:"config_id,pk"`
+	State                 string    `json:"state"`
+	ConsecutiveFailures   int       `json:"consecutiveFailures" bun:"consecutive_failures"`
+	OpenedUntil           time.Time `json:"openedUntil,omitempty" bun:"opened_until,nullzero"`
+	ProbeAttempt          int       `json:"probeAttempt" bun:"probe_attempt"`
+	LastFailureAt         time.Time `json:"lastFailureAt,omitempty" bun:"last_failure_at,nullzero"`
+	LastFailureStatusCode int       `json:"lastFailureStatusCode,omitempty" bun:"last_failure_status_code,nullzero"`
+	LastFailureReason     string    `json:"lastFailureReason,omitempty" bun:"last_failure_reason,nullzero"`
+	UpdatedAt             time.Time `json:"updatedAt" bun:"updated_at,nullzero,notnull,default:current_timestamp"`
+}
+
+type CircuitDecision struct {
+	Allowed     bool
+	Reason      string
+	OpenedUntil time.Time
+}
+
+type DeliveryFailure struct {
+	StatusCode int
+	Reason     string
+}
+
+type CircuitBreaker interface {
+	BeforeDelivery(ctx context.Context, configID string) (CircuitDecision, error)
+	RecordSuccess(ctx context.Context, configID string) error
+	RecordFailure(ctx context.Context, configID string, failure DeliveryFailure) error
+}
+
+func NewDeliveryCircuit(configID string) DeliveryCircuit {
+	return DeliveryCircuit{
+		ConfigID:            configID,
+		State:               CircuitStateClosed,
+		ConsecutiveFailures: 0,
+		ProbeAttempt:        0,
+		UpdatedAt:           time.Now().UTC(),
+	}
+}
+
+func CircuitProbeDelay(probeAttempt int) time.Duration {
+	delay := DefaultCircuitOpenDelay
+	for i := 0; i < probeAttempt; i++ {
+		delay *= 2
+		if delay >= DefaultCircuitMaxOpenDelay {
+			return DefaultCircuitMaxOpenDelay
+		}
+	}
+	return delay
+}

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -124,6 +124,36 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 				return errors.Wrap(err, "dropping redundant partial index for retry polling")
 			},
 		},
+		migrations.Migration{
+			Name: "Add webhook delivery circuits",
+			Up: func(ctx context.Context, tx bun.IDB) error {
+				_, err := tx.ExecContext(ctx, `
+					CREATE TABLE IF NOT EXISTS webhook_delivery_circuits (
+						config_id text PRIMARY KEY REFERENCES configs(id) ON DELETE CASCADE,
+						state text NOT NULL DEFAULT 'closed',
+						consecutive_failures integer NOT NULL DEFAULT 0,
+						opened_until timestamptz,
+						probe_attempt integer NOT NULL DEFAULT 0,
+						last_failure_at timestamptz,
+						last_failure_status_code integer,
+						last_failure_reason text,
+						updated_at timestamptz NOT NULL DEFAULT now(),
+						CONSTRAINT webhook_delivery_circuits_state_check
+							CHECK (state IN ('closed', 'open', 'half_open'))
+					)
+				`)
+				if err != nil {
+					return errors.Wrap(err, "creating webhook delivery circuits table")
+				}
+
+				_, err = tx.ExecContext(ctx, `
+					CREATE INDEX IF NOT EXISTS idx_webhook_delivery_circuits_opened_until
+					ON webhook_delivery_circuits (opened_until)
+					WHERE state = 'open'
+				`)
+				return errors.Wrap(err, "creating webhook delivery circuits opened_until index")
+			},
+		},
 	)
 
 	return migrator.Up(ctx)

--- a/pkg/storage/postgres/circuit_test.go
+++ b/pkg/storage/postgres/circuit_test.go
@@ -1,0 +1,192 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	webhooks "github.com/formancehq/webhooks/pkg"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestDeliveryCircuitCreatedClosedByDefault(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	decision, err := store.BeforeDelivery(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	require.Equal(t, webhooks.CircuitDecisionReasonClosed, decision.Reason)
+
+	circuit := selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateClosed, circuit.State)
+	require.Equal(t, 0, circuit.ConsecutiveFailures)
+	require.Equal(t, 0, circuit.ProbeAttempt)
+}
+
+func TestDeliveryCircuitOpensAfterFailureThreshold(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	for range webhooks.DefaultCircuitFailureThreshold - 1 {
+		require.NoError(t, store.RecordFailure(ctx, cfg.ID, webhooks.DeliveryFailure{StatusCode: 500}))
+	}
+
+	circuit := selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateClosed, circuit.State)
+	require.Equal(t, webhooks.DefaultCircuitFailureThreshold-1, circuit.ConsecutiveFailures)
+
+	beforeOpen := time.Now().UTC()
+	require.NoError(t, store.RecordFailure(ctx, cfg.ID, webhooks.DeliveryFailure{StatusCode: 500}))
+
+	circuit = selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateOpen, circuit.State)
+	require.Equal(t, webhooks.DefaultCircuitFailureThreshold, circuit.ConsecutiveFailures)
+	require.Equal(t, 0, circuit.ProbeAttempt)
+	require.WithinDuration(t, beforeOpen.Add(webhooks.DefaultCircuitOpenDelay), circuit.OpenedUntil, 2*time.Second)
+
+	decision, err := store.BeforeDelivery(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.False(t, decision.Allowed)
+	require.Equal(t, webhooks.CircuitDecisionReasonOpenUntil, decision.Reason)
+}
+
+func TestDeliveryCircuitAllowsSingleHalfOpenProbe(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+	openDeliveryCircuit(t, store, db, cfg.ID)
+
+	_, err = db.NewUpdate().
+		Model((*webhooks.DeliveryCircuit)(nil)).
+		Where("config_id = ?", cfg.ID).
+		Set("opened_until = ?", time.Now().UTC().Add(-time.Minute)).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	decision, err := store.BeforeDelivery(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	require.Equal(t, webhooks.CircuitDecisionReasonHalfOpenProbe, decision.Reason)
+
+	decision, err = store.BeforeDelivery(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.False(t, decision.Allowed)
+	require.Equal(t, webhooks.CircuitDecisionReasonProbeBusy, decision.Reason)
+
+	circuit := selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateHalfOpen, circuit.State)
+}
+
+func TestDeliveryCircuitReopensAfterFailedProbe(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+	openDeliveryCircuit(t, store, db, cfg.ID)
+
+	_, err = db.NewUpdate().
+		Model((*webhooks.DeliveryCircuit)(nil)).
+		Where("config_id = ?", cfg.ID).
+		Set("opened_until = ?", time.Now().UTC().Add(-time.Minute)).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	decision, err := store.BeforeDelivery(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+
+	beforeFailure := time.Now().UTC()
+	require.NoError(t, store.RecordFailure(ctx, cfg.ID, webhooks.DeliveryFailure{StatusCode: 500}))
+
+	circuit := selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateOpen, circuit.State)
+	require.Equal(t, 1, circuit.ProbeAttempt)
+	require.WithinDuration(t, beforeFailure.Add(webhooks.CircuitProbeDelay(1)), circuit.OpenedUntil, 2*time.Second)
+}
+
+func TestDeliveryCircuitClosesAfterSuccessfulProbe(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+	openDeliveryCircuit(t, store, db, cfg.ID)
+
+	_, err = db.NewUpdate().
+		Model((*webhooks.DeliveryCircuit)(nil)).
+		Where("config_id = ?", cfg.ID).
+		Set("state = ?", webhooks.CircuitStateHalfOpen).
+		Set("probe_attempt = 2").
+		Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, store.RecordSuccess(ctx, cfg.ID))
+
+	circuit := selectDeliveryCircuit(t, db, cfg.ID)
+	require.Equal(t, webhooks.CircuitStateClosed, circuit.State)
+	require.Equal(t, 0, circuit.ConsecutiveFailures)
+	require.Equal(t, 0, circuit.ProbeAttempt)
+	require.True(t, circuit.OpenedUntil.IsZero())
+	require.True(t, circuit.LastFailureAt.IsZero())
+	require.Equal(t, "", circuit.LastFailureReason)
+}
+
+func openDeliveryCircuit(t *testing.T, store interface {
+	RecordFailure(context.Context, string, webhooks.DeliveryFailure) error
+}, db interface {
+	NewSelect() *bun.SelectQuery
+}, configID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	for range webhooks.DefaultCircuitFailureThreshold {
+		require.NoError(t, store.RecordFailure(ctx, configID, webhooks.DeliveryFailure{StatusCode: 500}))
+	}
+
+	circuit := selectDeliveryCircuit(t, db, configID)
+	require.Equal(t, webhooks.CircuitStateOpen, circuit.State)
+}
+
+func selectDeliveryCircuit(t *testing.T, db interface {
+	NewSelect() *bun.SelectQuery
+}, configID string) webhooks.DeliveryCircuit {
+	t.Helper()
+
+	circuit := webhooks.DeliveryCircuit{}
+	require.NoError(t, db.NewSelect().
+		Model(&circuit).
+		Where("config_id = ?", configID).
+		Scan(context.Background()))
+	return circuit
+}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -258,6 +258,186 @@ func (s Store) InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error
 	return nil
 }
 
+func (s Store) BeforeDelivery(ctx context.Context, configID string) (webhooks.CircuitDecision, error) {
+	now := time.Now().UTC()
+
+	circuit, err := s.findDeliveryCircuit(ctx, s.db, configID)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return webhooks.CircuitDecision{}, errors.Wrap(err, "finding delivery circuit")
+		}
+
+		if err := ensureDeliveryCircuit(ctx, s.db, configID); err != nil {
+			return webhooks.CircuitDecision{}, errors.Wrap(err, "ensuring delivery circuit")
+		}
+		return webhooks.CircuitDecision{
+			Allowed: true,
+			Reason:  webhooks.CircuitDecisionReasonClosed,
+		}, nil
+	}
+
+	switch circuit.State {
+	case webhooks.CircuitStateClosed:
+		return webhooks.CircuitDecision{
+			Allowed: true,
+			Reason:  webhooks.CircuitDecisionReasonClosed,
+		}, nil
+	case webhooks.CircuitStateHalfOpen:
+		return webhooks.CircuitDecision{
+			Allowed: false,
+			Reason:  webhooks.CircuitDecisionReasonProbeBusy,
+		}, nil
+	case webhooks.CircuitStateOpen:
+		if !circuit.OpenedUntil.IsZero() && !circuit.OpenedUntil.After(now) {
+			claimed, err := s.claimHalfOpenProbe(ctx, configID, now)
+			if err != nil {
+				return webhooks.CircuitDecision{}, errors.Wrap(err, "claiming half-open probe")
+			}
+			if claimed {
+				return webhooks.CircuitDecision{
+					Allowed: true,
+					Reason:  webhooks.CircuitDecisionReasonHalfOpenProbe,
+				}, nil
+			}
+
+			return webhooks.CircuitDecision{
+				Allowed: false,
+				Reason:  webhooks.CircuitDecisionReasonProbeBusy,
+			}, nil
+		}
+
+		return webhooks.CircuitDecision{
+			Allowed:     false,
+			Reason:      webhooks.CircuitDecisionReasonOpenUntil,
+			OpenedUntil: circuit.OpenedUntil,
+		}, nil
+	default:
+		return webhooks.CircuitDecision{}, fmt.Errorf("unknown delivery circuit state %q", circuit.State)
+	}
+}
+
+func (s Store) RecordSuccess(ctx context.Context, configID string) error {
+	if err := ensureDeliveryCircuit(ctx, s.db, configID); err != nil {
+		return errors.Wrap(err, "ensuring delivery circuit")
+	}
+
+	_, err := s.db.NewUpdate().
+		Model((*webhooks.DeliveryCircuit)(nil)).
+		Where("config_id = ?", configID).
+		Set("state = ?", webhooks.CircuitStateClosed).
+		Set("consecutive_failures = 0").
+		Set("opened_until = NULL").
+		Set("probe_attempt = 0").
+		Set("last_failure_at = NULL").
+		Set("last_failure_status_code = NULL").
+		Set("last_failure_reason = NULL").
+		Set("updated_at = ?", time.Now().UTC()).
+		Exec(ctx)
+	return errors.Wrap(err, "recording delivery circuit success")
+}
+
+func (s Store) RecordFailure(ctx context.Context, configID string, failure webhooks.DeliveryFailure) error {
+	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if err := ensureDeliveryCircuit(ctx, tx, configID); err != nil {
+			return errors.Wrap(err, "ensuring delivery circuit")
+		}
+
+		circuit, err := s.findDeliveryCircuit(ctx, tx, configID)
+		if err != nil {
+			return errors.Wrap(err, "finding delivery circuit")
+		}
+
+		now := time.Now().UTC()
+		circuit.ConsecutiveFailures++
+		circuit.LastFailureAt = now
+		circuit.LastFailureStatusCode = failure.StatusCode
+		circuit.LastFailureReason = deliveryFailureReason(failure)
+		circuit.UpdatedAt = now
+
+		switch circuit.State {
+		case webhooks.CircuitStateHalfOpen:
+			circuit.State = webhooks.CircuitStateOpen
+			circuit.ProbeAttempt++
+			circuit.OpenedUntil = now.Add(webhooks.CircuitProbeDelay(circuit.ProbeAttempt))
+		case webhooks.CircuitStateClosed:
+			if circuit.ConsecutiveFailures >= webhooks.DefaultCircuitFailureThreshold {
+				circuit.State = webhooks.CircuitStateOpen
+				circuit.ProbeAttempt = 0
+				circuit.OpenedUntil = now.Add(webhooks.DefaultCircuitOpenDelay)
+			}
+		case webhooks.CircuitStateOpen:
+			// A race can record a failure after another worker already opened the
+			// circuit. Keep the current open window and only refresh failure details.
+		default:
+			return fmt.Errorf("unknown delivery circuit state %q", circuit.State)
+		}
+
+		_, err = tx.NewUpdate().
+			Model(&circuit).
+			WherePK().
+			Column("state").
+			Column("consecutive_failures").
+			Column("opened_until").
+			Column("probe_attempt").
+			Column("last_failure_at").
+			Column("last_failure_status_code").
+			Column("last_failure_reason").
+			Column("updated_at").
+			Exec(ctx)
+		return errors.Wrap(err, "recording delivery circuit failure")
+	})
+}
+
+func (s Store) findDeliveryCircuit(ctx context.Context, db bun.IDB, configID string) (webhooks.DeliveryCircuit, error) {
+	circuit := webhooks.DeliveryCircuit{}
+	if err := db.NewSelect().
+		Model(&circuit).
+		Where("config_id = ?", configID).
+		For("UPDATE").
+		Scan(ctx); err != nil {
+		return webhooks.DeliveryCircuit{}, err
+	}
+	return circuit, nil
+}
+
+func (s Store) claimHalfOpenProbe(ctx context.Context, configID string, now time.Time) (bool, error) {
+	circuit := webhooks.DeliveryCircuit{}
+	err := s.db.NewRaw(`
+		UPDATE webhook_delivery_circuits
+		SET state = ?, updated_at = ?
+		WHERE config_id = ?
+		  AND state = ?
+		  AND opened_until <= ?
+		RETURNING *
+	`, webhooks.CircuitStateHalfOpen, now, configID, webhooks.CircuitStateOpen, now).Scan(ctx, &circuit)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func ensureDeliveryCircuit(ctx context.Context, db bun.IDB, configID string) error {
+	circuit := webhooks.NewDeliveryCircuit(configID)
+	_, err := db.NewInsert().
+		Model(&circuit).
+		On("CONFLICT (config_id) DO NOTHING").
+		Exec(ctx)
+	return err
+}
+
+func deliveryFailureReason(failure webhooks.DeliveryFailure) string {
+	if failure.Reason != "" {
+		return failure.Reason
+	}
+	if failure.StatusCode == 0 {
+		return "transport_error"
+	}
+	return fmt.Sprintf("status_code_%d", failure.StatusCode)
+}
+
 func (s Store) Close(ctx context.Context) error {
 	return s.db.Close()
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -16,6 +16,8 @@ var (
 )
 
 type Store interface {
+	webhooks.CircuitBreaker
+
 	FindManyConfigs(ctx context.Context, filter map[string]any) ([]webhooks.Config, error)
 	InsertOneConfig(ctx context.Context, cfg webhooks.ConfigUser) (webhooks.Config, error)
 	DeleteOneConfig(ctx context.Context, id string) error

--- a/pkg/worker/message_ack_test.go
+++ b/pkg/worker/message_ack_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/formancehq/go-libs/v2/publish"
+	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +147,50 @@ func TestProcessMessages_NackOnInsertFailureForRetry(t *testing.T) {
 	err = handler(msg)
 	assert.Error(t, err, "handler should return error when insert fails for a non-success attempt")
 	assert.Contains(t, err.Error(), "insert attempt")
+}
+
+func TestProcessMessages_SkipsDeliveryWhenCircuitOpen(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, nil)
+	store.decisions[cfg.ID] = webhooks.CircuitDecision{
+		Allowed: false,
+		Reason:  webhooks.CircuitDecisionReasonOpenUntil,
+	}
+
+	configStore := &mockStoreWithConfigs{
+		mockStore: store,
+		configs:   []webhooks.Config{cfg},
+	}
+
+	handler := processMessages(configStore, server.Client(), &noRetryPolicy{})
+
+	ev := publish.EventMessage{
+		Type: "test.event",
+	}
+	payload, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	msg := message.NewMessage("test-uuid", payload)
+
+	require.NoError(t, handler(msg))
+	assert.Equal(t, int32(0), callCount.Load())
+	assert.Len(t, store.inserted, 0)
 }
 
 // mockStoreWithConfigs extends mockStore to return pre-configured configs

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -126,6 +126,17 @@ func processMessages(store storage.Store, httpClient *http.Client, retryPolicy w
 		for _, cfg := range cfgs {
 			logging.FromContext(ctx).Debugf("dispatching webhook to config %s at %s", cfg.ID, cfg.Endpoint)
 
+			decision, err := store.BeforeDelivery(ctx, cfg.ID)
+			if err != nil {
+				return fmt.Errorf("checking delivery circuit for config %s: %w", cfg.ID, err)
+			}
+			if !decision.Allowed {
+				logging.FromContext(ctx).Debugf(
+					"skipping webhook delivery to config %s: circuit decision=%s",
+					cfg.ID, decision.Reason)
+				continue
+			}
+
 			attempt, attemptErr := webhooks.MakeAttempt(ctx, httpClient, retryPolicy, uuid.NewString(),
 				uuid.NewString(), 0, cfg, ev.IdempotencyKey, data, false)
 			if attemptErr != nil {
@@ -150,8 +161,35 @@ func processMessages(store storage.Store, httpClient *http.Client, retryPolicy w
 				}
 				continue
 			}
+
+			if err := recordCircuitResult(ctx, store, cfg.ID, attempt); err != nil {
+				logging.FromContext(ctx).Errorf("recording delivery circuit result for config %s: %s", cfg.ID, err)
+				span.RecordError(err)
+			}
 		}
 
 		return nil
+	}
+}
+
+func recordCircuitResult(ctx context.Context, circuit webhooks.CircuitBreaker, configID string, attempt webhooks.Attempt) error {
+	if attempt.Status == webhooks.StatusAttemptSuccess {
+		return circuit.RecordSuccess(ctx, configID)
+	}
+	return circuit.RecordFailure(ctx, configID, failureFromAttempt(attempt))
+}
+
+func failureFromAttempt(attempt webhooks.Attempt) webhooks.DeliveryFailure {
+	reason := "retryable_status"
+	if attempt.Status == webhooks.StatusAttemptFailed {
+		reason = "max_retries_reached"
+	}
+	if attempt.StatusCode == 0 {
+		reason = "transport_error"
+	}
+
+	return webhooks.DeliveryFailure{
+		StatusCode: attempt.StatusCode,
+		Reason:     reason,
 	}
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -133,6 +133,21 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 		return
 	}
 
+	decision, err := w.store.BeforeDelivery(ctx, atts[0].Config.ID)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("checking delivery circuit for webhook %s: %s", webhookID, err)
+		return
+	}
+	if !decision.Allowed {
+		if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptSuppressed); err != nil {
+			if errors.Is(err, storage.ErrAttemptsNotModified) {
+				return
+			}
+			logging.FromContext(ctx).Errorf("suppressing retry attempts for webhook %s: %s", webhookID, err)
+		}
+		return
+	}
+
 	var ev publish.EventMessage
 	if err := json.Unmarshal([]byte(atts[0].Payload), &ev); err != nil {
 		logging.FromContext(ctx).Errorf("unmarshalling payload for webhook %s: %s", webhookID, err)
@@ -150,6 +165,10 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 	if err := w.store.InsertOneAttempt(ctx, attempt); err != nil {
 		logging.FromContext(ctx).Errorf("inserting attempt for webhook %s: %s", webhookID, err)
 		return
+	}
+
+	if err := recordCircuitResult(ctx, w.store, atts[0].Config.ID, attempt); err != nil {
+		logging.FromContext(ctx).Errorf("recording delivery circuit result for webhook %s: %s", webhookID, err)
 	}
 
 	if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, attempt.Status); err != nil {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -17,18 +17,24 @@ import (
 
 // mockStore implements storage.Store with only the methods needed for retry tests.
 type mockStore struct {
-	mu         sync.Mutex
-	webhookIDs []string
-	attempts   map[string][]webhooks.Attempt
-	inserted   []webhooks.Attempt
-	updated    map[string]string // webhookID -> final status
+	mu               sync.Mutex
+	webhookIDs       []string
+	attempts         map[string][]webhooks.Attempt
+	inserted         []webhooks.Attempt
+	updated          map[string]string // webhookID -> final status
+	decisions        map[string]webhooks.CircuitDecision
+	circuitSuccesses map[string]int
+	circuitFailures  map[string]int
 }
 
 func newMockStore(webhookIDs []string, attempts map[string][]webhooks.Attempt) *mockStore {
 	return &mockStore{
-		webhookIDs: webhookIDs,
-		attempts:   attempts,
-		updated:    make(map[string]string),
+		webhookIDs:       webhookIDs,
+		attempts:         attempts,
+		updated:          make(map[string]string),
+		decisions:        make(map[string]webhooks.CircuitDecision),
+		circuitSuccesses: make(map[string]int),
+		circuitFailures:  make(map[string]int),
 	}
 }
 
@@ -63,6 +69,35 @@ func (m *mockStore) UpdateAttemptsStatus(_ context.Context, webhookID string, st
 }
 
 func (m *mockStore) RecoverStaleRetryingAttempts(_ context.Context, _ time.Duration) error {
+	return nil
+}
+
+func (m *mockStore) BeforeDelivery(_ context.Context, configID string) (webhooks.CircuitDecision, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if decision, ok := m.decisions[configID]; ok {
+		return decision, nil
+	}
+	return webhooks.CircuitDecision{
+		Allowed: true,
+		Reason:  webhooks.CircuitDecisionReasonClosed,
+	}, nil
+}
+
+func (m *mockStore) RecordSuccess(_ context.Context, configID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.circuitSuccesses[configID]++
+	return nil
+}
+
+func (m *mockStore) RecordFailure(_ context.Context, configID string, _ webhooks.DeliveryFailure) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.circuitFailures[configID]++
 	return nil
 }
 
@@ -127,6 +162,7 @@ func TestProcessWebhookRetrySuccess(t *testing.T) {
 	// A new attempt should have been inserted
 	require.Len(t, store.inserted, 1)
 	require.Equal(t, webhooks.StatusAttemptSuccess, store.inserted[0].Status)
+	require.Equal(t, 1, store.circuitSuccesses[cfg.ID])
 
 	// Status should have been updated to success
 	require.Equal(t, webhooks.StatusAttemptSuccess, store.updated[webhookID])
@@ -174,6 +210,53 @@ func TestProcessWebhookRetryFailure(t *testing.T) {
 	// A new attempt should have been inserted with "to retry" status
 	require.Len(t, store.inserted, 1)
 	require.Equal(t, webhooks.StatusAttemptToRetry, store.inserted[0].Status)
+	require.Equal(t, 1, store.circuitFailures[cfg.ID])
+}
+
+func TestProcessWebhookRetrySuppressedWhenCircuitOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HTTP server should not be called while circuit is open")
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		},
+	})
+	store.decisions[cfg.ID] = webhooks.CircuitDecision{
+		Allowed: false,
+		Reason:  webhooks.CircuitDecisionReasonOpenUntil,
+	}
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	require.NoError(t, err)
+
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	require.Len(t, store.inserted, 0)
+	require.Equal(t, webhooks.StatusAttemptSuppressed, store.updated[webhookID])
 }
 
 func TestPoolProcessesBatchInParallel(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a proposed ADR for reducing webhook retry amplification with delivery circuit breakers.
- Implement a per-webhook-config delivery circuit persisted in PostgreSQL.
- Gate initial deliveries and PostgreSQL retries on circuit state.
- Mark claimed retries as suppressed when the circuit is open, avoiding extra HTTP attempts and retry chains.
- Document the new suppressed status and circuit behavior.

## Validation
- go test ./...
- go test -race -covermode=atomic -tags it ./...
- nix develop --impure --command just pre-commit
- nix develop --impure --command just tests