### PR TITLE
feat(webhooks): stop retry storms — terminal 4xx, attempt cap, retention, metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Key design consequence: **the current state of a delivery is smeared across mult
 3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, re-send with `MakeAttempt` at `retry_attempt + 1`, insert the new attempt, then update the claimed rows to the outcome status.
 4. Sleep, repeat.
 
-Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 30 days).
+Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 72h) or `--max-attempts` is reached (default 15 attempts).
 
 ### 1.5 Security model
 
@@ -100,7 +100,7 @@ Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/
 
 ## 2. Known problems & limitations
 
-Ordered by severity. References point at the code as of today. The items marked **(prod)** have caused real production incidents — see [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod).
+Ordered by severity. References point at the code that produced the incidents; the Phase 1 fixes in this PR mitigate the retry-storm items called out below. The items marked **(prod)** have caused real production incidents — see [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod).
 
 ### 2.0 The core problem: retry-storm → backlog amplification (prod)
 
@@ -109,13 +109,16 @@ This is the recurring, money-burning failure mode behind every webhooks incident
 > A dead or misconfigured customer endpoint (wrong credentials, decommissioned URL, expired tunnel) → **every error is retried as if transient** → attempts pile up in `to retry` → the retry loop re-sends + the `attempts` table explodes → PostgreSQL/RDS load, **cross-AZ replication traffic, and AWS cost** blow up, drowning observability in noise.
 
 **Root cause 1 — no retryable/non-retryable distinction.**
-`MakeAttempt` treats *any* non-2xx response as `to retry` ([pkg/attempt.go:106-118](pkg/attempt.go:106)). A `403` (bad credentials), `404` (gone), or `405` (wrong method) is **permanent** but gets retried for the full `--abort-after` window anyway. There is no client-error short-circuit, no `Retry-After` honoring for `429`.
+Mitigated in this PR by terminal 4xx classification.
+Previously, `MakeAttempt` treated *any* non-2xx response as `to retry` ([pkg/attempt.go:106-118](pkg/attempt.go:106)). A `403` (bad credentials), `404` (gone), or `405` (wrong method) is **permanent** but was retried for the full `--abort-after` window anyway. There was no client-error short-circuit, no `Retry-After` honoring for `429`.
 
 **Root cause 2 — no circuit breaker, no max-attempt cap; `abort-after`=30d is the *only* bound.**
-With `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reaches 1h after ~7 retries (~2h cumulative), then fires **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. This exactly matches the observed Tenora "retry count up to 724". *This is why guardrails never bounded Tenora/Paynovate: there are none beyond the 30-day timer.*
+Partially mitigated in this PR by `--max-attempts` (default 15) and `--abort-after=72h`; the per-endpoint circuit breaker is still future work.
+With the previous `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reached 1h after ~7 retries (~2h cumulative), then fired **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. This exactly matches the observed Tenora "retry count up to 724". *This is why guardrails never bounded Tenora/Paynovate: there were none beyond the 30-day timer.*
 
 **Root cause 3 — orphaned attempts loop and are never reclaimed or purged.**
-Deleting/deactivating a config leaves `to retry` rows that the active-config join skips but nothing ever transitions to `failed` ([§2.1](#21-reliability--delivery-semantics)). Combined with zero retention ([§2.3](#23-scalability--data-growth)), the table only grows.
+Mitigated in this PR by retention cleanup for deleted and inactive configs.
+Deleting/deactivating a config used to leave `to retry` rows that the active-config join skipped but nothing ever transitioned to `failed` ([§2.1](#21-reliability--delivery-semantics)). Combined with zero retention ([§2.3](#23-scalability--data-growth)), the table only grew.
 
 **Production evidence:**
 
@@ -322,7 +325,11 @@ Key flags:
       --retry-batch-size int                 Webhook IDs claimed per tick (default 50)
       --min-backoff-delay duration           Minimum backoff delay (default 1m)
       --max-backoff-delay duration           Maximum backoff delay (default 1h)
-      --abort-after duration                 Mark failed after retrying this long (default 720h)
+      --abort-after duration                 Mark failed after retrying this long (default 72h)
+      --max-attempts int                     Hard cap on delivery attempts per webhook (default 15)
+      --retention-period duration            Attempts-table cleanup interval (default 1h)
+      --retention-success-delay duration     Retain success attempts before purging (default 720h)
+      --retention-failed-delay duration      Retain failed attempts before purging (default 2160h)
       --auto-migrate                         Run DB migrations on startup
       --storage-postgres-conn-string string  Postgres connection string
 ```

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Key design consequence: **the current state of a delivery is smeared across mult
 
 1. **Stale recovery** (≤ once/min): attempts stuck in `retrying` > 5 min (crashed worker) are reset to `to retry`.
 2. **Atomic claim** ([pkg/storage/postgres/postgres.go](pkg/storage/postgres/postgres.go) `FindWebhookIDsToRetry`): a CTE selects up to `--retry-batch-size` (default 50) distinct `webhook_id`s whose oldest due attempt is ready, joins `configs` on `attempts.config->>'id'` to keep only active configs, locks rows with `FOR UPDATE SKIP LOCKED` (multi-worker safe), and flips them to `retrying`.
-3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, re-send with `MakeAttempt` at `retry_attempt + 1`, insert the new attempt, then terminalize the claimed rows. If the new attempt is retryable, only the newly inserted row stays in `to retry`.
+3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, verify retry caps before calling the endpoint, re-send with `MakeAttempt` at `retry_attempt + 1`, then atomically insert the new attempt and terminalize the claimed rows. If the new attempt is retryable, only the newly inserted row stays in `to retry`.
 4. Sleep, repeat.
 
-Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 72h) or `--max-attempts` is reached (default 15 attempts).
+Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 10h) or `--max-attempts` is reached (default 15 attempts). With nominal backoff, 15 attempts are exhausted after about 9h03; `abort-after` is the elapsed-time backstop for `Retry-After`, downtime, and backlog delays.
 
 ### 1.5 Security model
 
@@ -113,7 +113,7 @@ Mitigated in this PR by terminal 4xx classification.
 Previously, `MakeAttempt` treated *any* non-2xx response as `to retry` ([pkg/attempt.go:106-118](pkg/attempt.go:106)). A `403` (bad credentials), `404` (gone), or `405` (wrong method) is **permanent** but was retried for the full `--abort-after` window anyway. There was no client-error short-circuit, no `Retry-After` honoring for `429`.
 
 **Root cause 2 — no circuit breaker, no max-attempt cap; `abort-after`=30d is the *only* bound.**
-Partially mitigated in this PR by `--max-attempts` (default 15) and `--abort-after=72h`; the per-endpoint circuit breaker is still future work.
+Partially mitigated in this PR by `--max-attempts` (default 15) and `--abort-after=10h`; the per-endpoint circuit breaker is still future work.
 With the previous `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reached 1h after ~7 retries (~2h cumulative), then fired **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. Production incidents confirmed that guardrails did not bound dead endpoints beyond the 30-day timer.
 
 **Root cause 3 — orphaned attempts loop and are never reclaimed or purged.**
@@ -202,7 +202,7 @@ Phased so that each step ships independently and de-risks the next one. Within a
 
 Goal: observe before changing anything.
 
-1. **OTel metrics** (S): counters/histograms for `webhooks_delivery_attempts_total{status,status_class}`, `webhooks_delivery_duration_seconds`, `webhooks_retry_queue_depth` (gauge from a cheap `count(*) where status='to retry'`), `webhooks_consumer_lag`. Wire to the existing OTLP pipeline; build the Grafana dashboard + alerts (queue depth, failure rate).
+1. **OTel metrics** (S): counters/histograms for `webhooks_delivery_attempts_total{status,status_class}`, `webhooks_delivery_duration_seconds`, `webhooks_retry_queue_depth` (capped gauge for `status='to retry'`), `webhooks_consumer_lag`. Wire to the existing OTLP pipeline; build the Grafana dashboard + alerts (queue depth, failure rate).
 2. **Real health checks** (S): DB ping on `/_healthcheck`; drop the per-probe Info log in the worker handler.
 3. **Load test harness** (M): a reproducible benchmark (k6 or Go) simulating one slow endpoint among N, to quantify the head-of-line problem and validate Phase 2.
 
@@ -211,7 +211,7 @@ Goal: observe before changing anything.
 These directly kill the [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) failure mode and the AWS cost bleed. Ship these first.
 
 1. **Terminal 4xx classification** (S): in `MakeAttempt`, mark `4xx` (except `408`/`429`) as `failed` immediately instead of `to retry`. Honor `Retry-After` for `429`. Kills the bulk of every observed storm (403/404/405 were the top error codes).
-2. **Circuit breaker + max-attempt cap** (M): per-config, after X consecutive failures stop claiming for a cooldown; hard-cap attempts (e.g. 15) independent of `--abort-after`. Lower the default `--abort-after` from 30d (720 retries) to something sane (e.g. 72h). Auto-disable endpoints failing > N days and flag them.
+2. **Circuit breaker + max-attempt cap** (M): per-config, after X consecutive failures stop claiming for a cooldown; hard-cap attempts (e.g. 15) independent of `--abort-after`. Lower the default `--abort-after` from 30d (720 retries) to something coherent with the attempt cap (default 10h). Auto-disable endpoints failing > N days and flag them.
 3. **Retention / compaction of `attempts`** (M): scheduled purge of `success` (30d) and `failed` (90d) rows + reclaim orphaned `to retry` for deleted/inactive configs → `failed`. This makes the proven manual cleanup path permanent and automatic.
 4. **Per-dependency observability** (S): the Phase 0 metrics, split by `service.name` / route / outbound dependency so the next endpoint incident is caught from a dashboard, not later by infrastructure billing.
 
@@ -221,7 +221,7 @@ These directly kill the [§2.0](#20-the-core-problem-retry-storm--backlog-amplif
 2. **Bound response reads** (S): `io.LimitReader(resp.Body, 64<<10)` in `MakeAttempt`; persist a truncated body excerpt on failure (useful for the future deliveries API).
 3. **Stop leaking secrets** (M): redact `secret` from list/get responses (keep it on create/rotate only — breaking change to coordinate with SDK/fctl); stop snapshotting the secret inside `attempts.config` (strip it before insert; the retry path re-reads it from `configs`).
 4. **Add jitter to backoff** (S): full jitter (`rand(0, delay)`) to de-synchronize retry herds onto recovering endpoints.
-5. **Transactional retry processing** (M): wrap `InsertOneAttempt` + `UpdateAttemptsStatus` in one transaction; make `UpdateAttemptsStatus` a single `UPDATE … RETURNING` (drop the pre-SELECT).
+5. **Retry update optimization** (M): make `UpdateAttemptsStatus` a single `UPDATE … RETURNING` (drop the pre-SELECT).
 6. **Fix graceful shutdown** (M): replace `time.Sleep` with `select { case <-ctx.Done(); case <-ticker.C }`, run the loop off the fx lifecycle context, remove the `default:` escape in `Stop`, drain the pond pool with a deadline.
 7. **API correctness** (S): `UpdateOneConfig` checks existence (404) and bumps `updated_at`; reject secret regeneration on PUT unless explicitly requested.
 
@@ -315,7 +315,7 @@ Key flags:
       --retry-batch-size int                 Webhook IDs claimed per tick (default 50)
       --min-backoff-delay duration           Minimum backoff delay (default 1m)
       --max-backoff-delay duration           Maximum backoff delay (default 1h)
-      --abort-after duration                 Mark failed after retrying this long (default 72h)
+      --abort-after duration                 Mark failed after retrying this long (default 10h)
       --max-attempts int                     Hard cap on delivery attempts per webhook (default 15)
       --retention-period duration            Attempts-table cleanup interval (default 1h)
       --retention-success-delay duration     Retain success attempts before purging (default 720h)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The binary has two run modes (a third `retries` mode mentioned in older docs no 
 
 Both are wired with `uber/fx` dependency injection, share a PostgreSQL database (via `bun`), and are configured through `cobra`/`pflag` flags (see [cmd/flag/flags.go](cmd/flag/flags.go)).
 
-```
+```text
 ┌─────────────────┐      ┌───────────────────────────┐      ┌──────────────────┐
 │  Kafka / NATS   │─────▶│          Worker           │─────▶│  User Endpoints  │
 │ (event source)  │      │ ┌───────────┐ ┌─────────┐ │      │ (webhook targets)│
@@ -114,25 +114,15 @@ Previously, `MakeAttempt` treated *any* non-2xx response as `to retry` ([pkg/att
 
 **Root cause 2 — no circuit breaker, no max-attempt cap; `abort-after`=30d is the *only* bound.**
 Partially mitigated in this PR by `--max-attempts` (default 15) and `--abort-after=72h`; the per-endpoint circuit breaker is still future work.
-With the previous `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reached 1h after ~7 retries (~2h cumulative), then fired **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. This exactly matches the observed Tenora "retry count up to 724". *This is why guardrails never bounded Tenora/Paynovate: there were none beyond the 30-day timer.*
+With the previous `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reached 1h after ~7 retries (~2h cumulative), then fired **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. Production incidents confirmed that guardrails did not bound dead endpoints beyond the 30-day timer.
 
 **Root cause 3 — orphaned attempts loop and are never reclaimed or purged.**
 Mitigated in this PR by retention cleanup for deleted and inactive configs.
 Deleting/deactivating a config used to leave `to retry` rows that the active-config join skipped but nothing ever transitioned to `failed` ([§2.1](#21-reliability--delivery-semantics)). Combined with zero retention ([§2.3](#23-scalability--data-growth)), the table only grew.
 
-**Production evidence:**
+**Sanitized production evidence:** retry storms were dominated by permanent endpoint failures, orphaned attempts stayed indefinitely in `to retry`, large `attempts` tables made the retry-claim query expensive, and manual cleanup materially reduced cross-AZ database replication traffic. Detailed incident evidence lives in internal runbooks.
 
-| Incident | Symptom | Source |
-|----------|---------|--------|
-| Hosting retry storm | **467k errors / 6h** (503 Paynovate test, 403 Paynovate creds, 405 example.com, 404 ngrok, 500 Xano) ≈ **1.9M DB requests/6h** | AWS-Cost-Investigation-Webhooks-Retry-Storm |
-| Orphaned attempts | **64M** attempt rows with no config, **3.6M** stuck in `to retry` looping forever | idem |
-| Cleanup payoff (2026-04-10) | cross-AZ Webhooks DB traffic **145 GB → 0.3 GB / 15 min**, est. **~$39k/yr** saved | idem |
-| Bad query plan | retry-claim query **~54s** vs **1.3ms** with the right index on a ~120-167 GB table; PR #150 fixed plan → **0.107 ms** | Codex AWS Cost Analysis 2026-05-20 |
-| Paynovate (live) | `api.baas.paynovate.com/hooks/formance`: **59,423 × 403 / 24h** = **39.17%** endpoint error rate | Webhooks Error Analysis 2026-06-09 |
-| Tenora staging | retry storm to a `loca.lt` tunnel (mostly 503), **~907k** `to retry`, retry count **up to 724**, **~39 GB** table | Tenora AWS Cost Spike 2026-06-09 |
-| Kulu | undetected broken endpoint: **13-14M errors**, retries **up to 21×**, **27.7M** transactions affected | Kulu Daily Sync 2026-03-26 |
-
-**Immediate priorities** (detailed in the plan): (a) treat permanent 4xx as terminal, (b) add a per-endpoint circuit breaker + max-attempt cap, (c) implement retention/compaction of `attempts`, (d) split observability by `service.name`/route/external dependency (the "slow Deriv POSTs" were actually Webhooks→Xano outbound calls, not Ledger latency — Deriv Error Analysis 2026-05-22).
+**Immediate priorities** (detailed in the plan): (a) treat permanent 4xx as terminal, (b) add a per-endpoint circuit breaker + max-attempt cap, (c) implement retention/compaction of `attempts`, (d) split observability by `service.name`/route/external dependency so outbound delivery latency is not misdiagnosed as internal service latency.
 
 ### 2.1 Reliability & delivery semantics
 
@@ -176,7 +166,7 @@ If the HTTP delivery succeeded but `InsertOneAttempt` fails, we `continue` and a
 ### 2.3 Scalability & data growth
 
 **P0 — Unbounded `attempts` table → cross-AZ cost. (prod)**
-No retention, no archival, no partitioning. Every delivery stores the full payload + full config snapshot; `success` rows are kept forever. Tables reached **120-167 GB** (Paynovate); the table churn drives **cross-AZ RDS replication traffic** that dominated the AWS bill — the 2026-04-10 orphan cleanup alone cut cross-AZ traffic from **145 GB → 0.3 GB per 15 min (~$39k/yr)**. Growth also degrades the retry-claim CTE (`NOT EXISTS` anti-join over hundreds of thousands of `to retry` rows — Tenora had ~907k) and inflates backups. Retention is **not optional**, it is the proven highest-ROI fix.
+No retention, no archival, no partitioning. Every delivery stores the full payload + full config snapshot; `success` rows are kept forever. Large attempts tables drive cross-AZ RDS replication traffic, inflate backups, and degrade the retry-claim CTE (`NOT EXISTS` anti-join over a large `to retry` backlog). Retention is **not optional**, it is the proven highest-ROI fix.
 
 **P2 — Retry throughput ceiling.**
 Polling claims ≤ 50 webhook IDs per 3s tick per worker (~16/s). The claim query joins on the JSONB expression `attempts.config->>'id'` (no expression index) and re-reads attempts twice per webhook (`FindAttemptsToRetryByWebhookID`, then `UpdateAttemptsStatus` does another SELECT before its UPDATE). During a large outage of a popular endpoint, the backlog drains slowly and the herd retries without jitter, synchronizing load spikes onto the recovering endpoint.
@@ -195,7 +185,7 @@ Polling claims ≤ 50 webhook IDs per 3s tick per worker (~16/s). The claim quer
 
 ### 2.5 Operability & code health
 
-- **No metrics, no per-dependency split. (prod)** Only traces + logs. No delivery success rate, retry-queue depth, end-to-end latency, or per-endpoint error rate → incidents are debugged with SQL (cf. the recent `skip locked` / `active configs` firefighting in #147, #150). Worse, outbound delivery latency is not attributed: the "slow Deriv POSTs" turned out to be Webhooks→Xano outbound calls, misdiagnosed as internal Ledger latency. Dashboards must split by `service.name`, route, and external dependency.
+- **No metrics, no per-dependency split. (prod)** Only traces + logs. No delivery success rate, retry-queue depth, end-to-end latency, or per-endpoint error rate → incidents are debugged with SQL (cf. the recent `skip locked` / `active configs` firefighting in #147, #150). Worse, outbound delivery latency is not attributed clearly enough and can be misdiagnosed as internal service latency. Dashboards must split by `service.name`, route, and external dependency.
 - **Health checks are no-ops**: server `/_healthcheck` returns an empty 200 with no DB check; the worker healthcheck logs `health check OK` at *Info* level on every probe (log spam).
 - **Mixed dependency generations**: `go-libs/v2` everywhere with `go-libs/v5` bolted on for audit only; `logrus` + go-libs logging coexist; `pkg/errors` is deprecated.
 - **Package layout**: the root `pkg` package (`webhooks`) is a grab-bag of domain model + HTTP delivery + backoff contract; the generated Speakeasy SDK (~100 files) is vendored in-tree with a `replace`, inflating the module and the diff noise.
@@ -212,7 +202,7 @@ Phased so that each step ships independently and de-risks the next one. Within a
 
 Goal: observe before changing anything.
 
-1. **OTel metrics** (S): counters/histograms for `webhooks_delivery_total{status,event_type}`, `webhooks_delivery_duration_seconds`, `webhooks_retry_queue_depth` (gauge from a cheap `count(*) where status='to retry'`), `webhooks_consumer_lag`. Wire to the existing OTLP pipeline; build the Grafana dashboard + alerts (queue depth, failure rate).
+1. **OTel metrics** (S): counters/histograms for `webhooks_delivery_attempts_total{status,status_class}`, `webhooks_delivery_duration_seconds`, `webhooks_retry_queue_depth` (gauge from a cheap `count(*) where status='to retry'`), `webhooks_consumer_lag`. Wire to the existing OTLP pipeline; build the Grafana dashboard + alerts (queue depth, failure rate).
 2. **Real health checks** (S): DB ping on `/_healthcheck`; drop the per-probe Info log in the worker handler.
 3. **Load test harness** (M): a reproducible benchmark (k6 or Go) simulating one slow endpoint among N, to quantify the head-of-line problem and validate Phase 2.
 
@@ -222,8 +212,8 @@ These directly kill the [§2.0](#20-the-core-problem-retry-storm--backlog-amplif
 
 1. **Terminal 4xx classification** (S): in `MakeAttempt`, mark `4xx` (except `408`/`429`) as `failed` immediately instead of `to retry`. Honor `Retry-After` for `429`. Kills the bulk of every observed storm (403/404/405 were the top error codes).
 2. **Circuit breaker + max-attempt cap** (M): per-config, after X consecutive failures stop claiming for a cooldown; hard-cap attempts (e.g. 15) independent of `--abort-after`. Lower the default `--abort-after` from 30d (720 retries) to something sane (e.g. 72h). Auto-disable endpoints failing > N days and flag them.
-3. **Retention / compaction of `attempts`** (M): scheduled purge of `success` (30d) and `failed` (90d) rows + reclaim orphaned `to retry` for deleted/inactive configs → `cancelled`. This is the change that produced the **~$39k/yr** cross-AZ saving; make it permanent and automatic instead of a manual one-off.
-4. **Per-dependency observability** (S): the Phase 0 metrics, split by `service.name` / route / outbound dependency so the next Tenora/Paynovate/Deriv case is caught from a dashboard, not 24h later by AWS billing.
+3. **Retention / compaction of `attempts`** (M): scheduled purge of `success` (30d) and `failed` (90d) rows + reclaim orphaned `to retry` for deleted/inactive configs → `failed`. This makes the proven manual cleanup path permanent and automatic.
+4. **Per-dependency observability** (S): the Phase 0 metrics, split by `service.name` / route / outbound dependency so the next endpoint incident is caught from a dashboard, not later by infrastructure billing.
 
 ### Phase 1b — Security & correctness quick wins (1–2 sprints, no schema change)
 
@@ -239,7 +229,7 @@ These directly kill the [§2.0](#20-the-core-problem-retry-storm--backlog-amplif
 
 The structural fix for head-of-line blocking, duplicates, and the convoluted claim query. Target model:
 
-```
+```text
 events ──▶ consumer: INSERT deliveries (outbox) ──▶ ACK immediately
                               │
               dispatcher pool (same claim pattern,
@@ -283,32 +273,32 @@ Phase 1 ships a retention job on the legacy `attempts` table; this phase makes i
 | Phase | Theme | Risk addressed | Effort |
 |-------|-------|----------------|--------|
 | 0 | Metrics & health | Flying blind | ~1 sprint |
-| **1** | **Stop retry storms (terminal 4xx, circuit breaker, retention, per-dep metrics)** | **Retry storms, ~$39k/yr cross-AZ cost, undetected dead endpoints** | **~1 sprint** |
+| **1** | **Stop retry storms (terminal 4xx, circuit breaker, retention, per-dep metrics)** | **Retry storms, cross-AZ cost, undetected dead endpoints** | **~1 sprint** |
 | 1b | Security/correctness quick wins | SSRF, secret leaks, dup retries, shutdown | 1–2 sprints |
 | 2 | Outbox + deliveries model | Head-of-line blocking, duplicates, claim complexity | 2–3 sprints |
 | 3 | Retention hardening | Unbounded growth (new model) | ~1 sprint |
 | 4 | Deliveries API, replay, rotation | Supportability, product parity | 1–2 sprints |
 | 5 | Code modernization | Maintenance drag | continuous |
 
-> **If you do only one thing this quarter:** Phase 1. Terminal-4xx + circuit breaker + automatic retention would have prevented every incident in the [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) table and the recurring AWS cost spikes.
+> **If you do only one thing this quarter:** Phase 1. Terminal-4xx + circuit breaker + automatic retention would have prevented the incident class described in [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) and the recurring DB I/O and cost spikes.
 
 ---
 
 ## 4. Development
 
 Run the linters:
-```
+```sh
 earthly +lint
 ```
 
 Run the tests:
-```
+```sh
 earthly -P +tests
 ```
 
 ### Usage
 
-```
+```text
 Usage:
   webhooks [command]
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,297 @@
-# Webhooks
+# Formance Webhooks
 
-Webhooks is a service used to manage user configs and send webhooks to endpoints.
-A user config is made of the following information:
-- Endpoint: a single URL where messages are sent to.
-- EventTypes: an array of string identifiers denoting the type of message being sent and are the primary way for webhook consumers to configure what events they are interested in receiving. Are stored in lower-case format.
-- Secret: a string used to verify received webhooks. Every webhook and its metadata is signed with a unique key for each endpoint. This signature can then be used to verify the webhook indeed comes from this service.
-  The format is a random string of bytes of size 24, base64 encoded. (larger size after encoding)
+Webhooks is the Formance service responsible for delivering platform events (ledger, payments, …) to user-configured HTTP endpoints, with HMAC signing and automatic retries.
 
-The service has 3 starting modes, split into 3 separate commands:
+This document covers three things:
 
-- `server`: REST web service API managing webhooks configs for users.
-- `worker`: background service consuming kafka events on selected topics to send webhooks based on user configs and periodically finding failed webhooks requests to retry and sending new attempts.
+1. [Architecture deep-dive](#1-architecture-deep-dive) — how the service actually works today
+2. [Known problems & limitations](#2-known-problems--limitations) — a detailed inventory of the issues we are facing
+3. [Improvement plan](#3-improvement-plan) — a phased, prioritized roadmap to fix them
 
-## Run linters and tests 
+---
+
+## 1. Architecture deep-dive
+
+### 1.1 Components
+
+The binary has two run modes (a third `retries` mode mentioned in older docs no longer exists):
+
+| Command | Role |
+|---------|------|
+| `serve` | REST API for managing webhook configs (CRUD, activate/deactivate, secret rotation, test delivery). Can optionally embed the worker with `--worker`. |
+| `worker` | Background service: consumes events from Kafka/NATS via [Watermill](https://watermill.io/), delivers webhooks, and runs the retry loop (`Retrier`). Exposes only a `/_healthcheck` endpoint. |
+
+Both are wired with `uber/fx` dependency injection, share a PostgreSQL database (via `bun`), and are configured through `cobra`/`pflag` flags (see [cmd/flag/flags.go](cmd/flag/flags.go)).
+
+```
+┌─────────────────┐      ┌───────────────────────────┐      ┌──────────────────┐
+│  Kafka / NATS   │─────▶│          Worker           │─────▶│  User Endpoints  │
+│ (event source)  │      │ ┌───────────┐ ┌─────────┐ │      │ (webhook targets)│
+└─────────────────┘      │ │ Consumer  │ │ Retrier │ │      └──────────────────┘
+                         │ │ (inline   │ │ (DB     │ │
+                         │ │  send)    │ │  poll)  │ │
+                         │ └─────┬─────┘ └────┬────┘ │
+                         └───────┼────────────┼──────┘
+                                 ▼            ▼
+┌─────────────────┐      ┌───────────────────────────┐
+│   API Clients   │─────▶│        PostgreSQL         │
+│  (fctl, SDKs)   │◀─────│   configs + attempts      │
+└─────────────────┘      └───────────────────────────┘
+         ▲
+         │
+┌────────┴─────────┐
+│      Server      │  REST API + OAuth2 auth + audit middleware
+└──────────────────┘
+```
+
+### 1.2 Data model
+
+Two tables only ([pkg/config.go](pkg/config.go), [pkg/attempt.go](pkg/attempt.go)):
+
+**`configs`** — a webhook subscription:
+- `id` (UUID, PK), `endpoint` (URL), `event_types` (text array), `secret` (base64, 24 random bytes), `active` (bool), `name`, `created_at`, `updated_at`
+
+**`attempts`** — one row **per delivery attempt** (not per delivery):
+- `id` (UUID, PK), `webhook_id` (groups all attempts of one event×config pair)
+- `config` (**JSONB snapshot of the full config at send time, including the secret**)
+- `payload` (full event JSON as text), `status_code`, `retry_attempt`, `status`, `next_retry_after`
+
+Statuses: `success`, `to retry`, `retrying` (claimed by a worker), `failed` (retry window exhausted).
+
+Key design consequence: **the current state of a delivery is smeared across multiple rows**. Each retry inserts a *new* attempt row, and the previous `retrying` rows are bulk-updated to the new status (`UpdateAttemptsStatus`). There is no `deliveries` aggregate.
+
+### 1.3 Event consumption path (hot path)
+
+[pkg/worker/module.go](pkg/worker/module.go) — `processMessages`:
+
+1. Watermill delivers a message; payload is unmarshalled into `publish.EventMessage`.
+2. Event type is normalized to `<app>.<type>` lower-case.
+3. `FindManyConfigs({event_types, active: true})` finds matching configs.
+4. **For each config, sequentially and synchronously**, `MakeAttempt` POSTs the payload to the endpoint (30s HTTP timeout, [pkg/otlp/module.go](pkg/otlp/module.go)).
+5. The resulting attempt row (`success` or `to retry`) is inserted.
+6. The message is acked when the handler returns `nil`; if persisting a *retryable* attempt fails, the handler returns an error → nack → broker redelivery.
+7. `context.WithoutCancel` detaches the handler from shutdown cancellation so in-flight sends complete.
+
+### 1.4 Retry path
+
+[pkg/worker/worker.go](pkg/worker/worker.go) — the `Retrier` loop, every `--retry-period` (default 3s):
+
+1. **Stale recovery** (≤ once/min): attempts stuck in `retrying` > 5 min (crashed worker) are reset to `to retry`.
+2. **Atomic claim** ([pkg/storage/postgres/postgres.go](pkg/storage/postgres/postgres.go) `FindWebhookIDsToRetry`): a CTE selects up to `--retry-batch-size` (default 50) distinct `webhook_id`s whose oldest due attempt is ready, joins `configs` on `attempts.config->>'id'` to keep only active configs, locks rows with `FOR UPDATE SKIP LOCKED` (multi-worker safe), and flips them to `retrying`.
+3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, re-send with `MakeAttempt` at `retry_attempt + 1`, insert the new attempt, then update the claimed rows to the outcome status.
+4. Sleep, repeat.
+
+Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 30 days).
+
+### 1.5 Security model
+
+[pkg/security/security.go](pkg/security/security.go) — Svix-style signing:
+
+- Signed string: `{webhook_id}.{unix_timestamp}.{body}`, HMAC-SHA256 with the config secret, sent as `formance-webhook-signature: v1,<base64>`.
+- Headers: `formance-webhook-id`, `-timestamp`, `-test`, `-idempotency-key` (propagated from the event).
+- API auth: OAuth2 via `go-libs/auth` middleware; audit middleware publishes API calls to an `audit-events` topic.
+
+### 1.6 Testing & tooling
+
+- E2E ginkgo suite ([test/e2e](test/e2e)) running against a real Postgres + NATS through the generated Speakeasy SDK ([pkg/client](pkg/client), vendored with a `replace` directive).
+- Earthly for lint/tests, Nix flake for the dev shell, GoReleaser for releases.
+
+---
+
+## 2. Known problems & limitations
+
+Ordered by severity. References point at the code as of today. The items marked **(prod)** have caused real production incidents — see [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod).
+
+### 2.0 The core problem: retry-storm → backlog amplification (prod)
+
+This is the recurring, money-burning failure mode behind every webhooks incident we have had. The chain:
+
+> A dead or misconfigured customer endpoint (wrong credentials, decommissioned URL, expired tunnel) → **every error is retried as if transient** → attempts pile up in `to retry` → the retry loop re-sends + the `attempts` table explodes → PostgreSQL/RDS load, **cross-AZ replication traffic, and AWS cost** blow up, drowning observability in noise.
+
+**Root cause 1 — no retryable/non-retryable distinction.**
+`MakeAttempt` treats *any* non-2xx response as `to retry` ([pkg/attempt.go:106-118](pkg/attempt.go:106)). A `403` (bad credentials), `404` (gone), or `405` (wrong method) is **permanent** but gets retried for the full `--abort-after` window anyway. There is no client-error short-circuit, no `Retry-After` honoring for `429`.
+
+**Root cause 2 — no circuit breaker, no max-attempt cap; `abort-after`=30d is the *only* bound.**
+With `min-backoff=1m` doubling to a `max-backoff=1h` cap, the delay reaches 1h after ~7 retries (~2h cumulative), then fires **once per hour for 30 days ≈ 718 more** → **~724 attempts per dead endpoint**. This exactly matches the observed Tenora "retry count up to 724". *This is why guardrails never bounded Tenora/Paynovate: there are none beyond the 30-day timer.*
+
+**Root cause 3 — orphaned attempts loop and are never reclaimed or purged.**
+Deleting/deactivating a config leaves `to retry` rows that the active-config join skips but nothing ever transitions to `failed` ([§2.1](#21-reliability--delivery-semantics)). Combined with zero retention ([§2.3](#23-scalability--data-growth)), the table only grows.
+
+**Production evidence:**
+
+| Incident | Symptom | Source |
+|----------|---------|--------|
+| Hosting retry storm | **467k errors / 6h** (503 Paynovate test, 403 Paynovate creds, 405 example.com, 404 ngrok, 500 Xano) ≈ **1.9M DB requests/6h** | AWS-Cost-Investigation-Webhooks-Retry-Storm |
+| Orphaned attempts | **64M** attempt rows with no config, **3.6M** stuck in `to retry` looping forever | idem |
+| Cleanup payoff (2026-04-10) | cross-AZ Webhooks DB traffic **145 GB → 0.3 GB / 15 min**, est. **~$39k/yr** saved | idem |
+| Bad query plan | retry-claim query **~54s** vs **1.3ms** with the right index on a ~120-167 GB table; PR #150 fixed plan → **0.107 ms** | Codex AWS Cost Analysis 2026-05-20 |
+| Paynovate (live) | `api.baas.paynovate.com/hooks/formance`: **59,423 × 403 / 24h** = **39.17%** endpoint error rate | Webhooks Error Analysis 2026-06-09 |
+| Tenora staging | retry storm to a `loca.lt` tunnel (mostly 503), **~907k** `to retry`, retry count **up to 724**, **~39 GB** table | Tenora AWS Cost Spike 2026-06-09 |
+| Kulu | undetected broken endpoint: **13-14M errors**, retries **up to 21×**, **27.7M** transactions affected | Kulu Daily Sync 2026-03-26 |
+
+**Immediate priorities** (detailed in the plan): (a) treat permanent 4xx as terminal, (b) add a per-endpoint circuit breaker + max-attempt cap, (c) implement retention/compaction of `attempts`, (d) split observability by `service.name`/route/external dependency (the "slow Deriv POSTs" were actually Webhooks→Xano outbound calls, not Ledger latency — Deriv Error Analysis 2026-05-22).
+
+### 2.1 Reliability & delivery semantics
+
+**P0 — Permanent errors retried as transient. (prod)**
+See [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) root cause 1. The fix is small and high-impact: classify `4xx` (except `408`/`429`) as `failed` immediately in `MakeAttempt`.
+
+**P0 — No circuit breaker / max-attempt cap. (prod)**
+See [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) root cause 2. ~724 retries per dead endpoint is by design today.
+
+**P1 — Head-of-line blocking on the consumer hot path.**
+`processMessages` sends webhooks **inline, sequentially, inside the broker handler** ([pkg/worker/module.go:126](pkg/worker/module.go:126)). One slow endpoint (up to the 30s timeout) stalls the whole topic/partition; with N matching configs a single message can hold the handler for N×30s. Consumer lag builds up under load and *every* customer is penalized by one bad endpoint. This is the single biggest scalability flaw.
+
+**P1 — Broker redelivery causes duplicate sends to healthy endpoints.**
+If `InsertOneAttempt` fails for one config's retryable attempt, the handler nacks the whole message ([pkg/worker/module.go:143-151](pkg/worker/module.go:143)). On redelivery, the event is re-sent to **all** matching configs, including those that already received it successfully. There is no per-(event, config) deduplication (no unique constraint, `msg.UUID` is not used as an idempotency key in storage).
+
+**P1 — Crash window produces duplicate retries.**
+In `processWebhookRetry`, the new attempt is inserted *before* the claimed rows are flipped out of `retrying` ([pkg/worker/worker.go:150-160](pkg/worker/worker.go:150)), and the two writes are **not in a transaction**. A crash in between leaves old rows in `retrying`; stale recovery resets them to `to retry` 5 minutes later, and the webhook is sent again even though a fresh `to retry` attempt row already exists — duplicate deliveries and divergent attempt counters.
+
+**P2 — Deleted configs strand attempts forever.**
+The claim query filters on `configs.active = true` via a join. Deleting a config (`DELETE /configs/{id}`) leaves its `to retry` attempts orphaned: never claimable, never transitioned to `failed`, polluting the partial indexes indefinitely. Deactivating then reactivating a config also silently *resumes* old retries, which may be surprising.
+
+**P2 — Graceful shutdown is unreliable.**
+`Retrier.Stop` has a `default:` branch that gives up immediately if the loop is mid-batch ("no communication", [pkg/worker/worker.go:75](pkg/worker/worker.go:75)). The loop itself uses bare `time.Sleep` rather than a context-aware timer, and `run()` launches it with `context.Background()` ([pkg/worker/module.go:50](pkg/worker/module.go:50)), so fx shutdown cannot cancel it. In-flight batches can be killed mid-write on pod termination, feeding the stale-recovery duplicate path above.
+
+**P3 — Lost audit rows on insert failure after success.**
+If the HTTP delivery succeeded but `InsertOneAttempt` fails, we `continue` and ack: delivery happened but no trace of it exists in the DB.
+
+### 2.2 Security
+
+**P1 — No SSRF protection.**
+`endpoint` is any URL that `url.Parse` accepts ([pkg/config.go:50](pkg/config.go:50)). The worker will happily POST signed payloads to `http://169.254.169.254/`, internal services, or `localhost`. No scheme allow-list (plain `http` accepted), no private/link-local IP deny-list, no DNS-rebinding protection, and the default `http.Client` follows redirects (a public endpoint can 302 to an internal one).
+
+**P1 — Secrets are over-exposed.**
+- Returned in clear text by every config API response (`Config` embeds `ConfigUser` with `json:"secret"`), including `GET /configs` and the `/test` response (which embeds the full config snapshot in the attempt).
+- **Snapshotted into every `attempts.config` JSONB row** — rotating a secret does not remove the old one from potentially millions of historical rows.
+- Stored in plain text in Postgres (no envelope encryption).
+
+**P2 — Unbounded response body read.**
+`io.ReadAll(resp.Body)` in `MakeAttempt` ([pkg/attempt.go:91](pkg/attempt.go:91)) reads whatever the remote endpoint returns, with no `io.LimitReader`. A malicious or buggy endpoint can OOM the worker. The body is only used for a debug log.
+
+### 2.3 Scalability & data growth
+
+**P0 — Unbounded `attempts` table → cross-AZ cost. (prod)**
+No retention, no archival, no partitioning. Every delivery stores the full payload + full config snapshot; `success` rows are kept forever. Tables reached **120-167 GB** (Paynovate); the table churn drives **cross-AZ RDS replication traffic** that dominated the AWS bill — the 2026-04-10 orphan cleanup alone cut cross-AZ traffic from **145 GB → 0.3 GB per 15 min (~$39k/yr)**. Growth also degrades the retry-claim CTE (`NOT EXISTS` anti-join over hundreds of thousands of `to retry` rows — Tenora had ~907k) and inflates backups. Retention is **not optional**, it is the proven highest-ROI fix.
+
+**P2 — Retry throughput ceiling.**
+Polling claims ≤ 50 webhook IDs per 3s tick per worker (~16/s). The claim query joins on the JSONB expression `attempts.config->>'id'` (no expression index) and re-reads attempts twice per webhook (`FindAttemptsToRetryByWebhookID`, then `UpdateAttemptsStatus` does another SELECT before its UPDATE). During a large outage of a popular endpoint, the backlog drains slowly and the herd retries without jitter, synchronizing load spikes onto the recovering endpoint.
+
+**P2 — `GET /configs` has no pagination.**
+`FindManyConfigs` selects all rows ([pkg/storage/postgres/postgres.go:27](pkg/storage/postgres/postgres.go:27)); the handler wraps the full result in a fake `Cursor` ([pkg/server/get.go](pkg/server/get.go)). Same for the per-event-type lookup on the hot path — fine today, unbounded by design.
+
+### 2.4 API & product gaps
+
+- **No delivery visibility**: there is no endpoint to list attempts/deliveries, inspect failures, or **manually replay** a webhook. Support has to query Postgres by hand.
+- **PUT `/configs/{id}` on an unknown id returns 200**: `Store.UpdateOneConfig` never checks existence, so the `ErrConfigNotFound` branch in [pkg/server/update.go:35](pkg/server/update.go:35) is dead code. It also doesn't bump `updated_at`.
+- **Update replaces the secret silently**: `PUT /configs/{id}` regenerates a secret when none is provided (via `Validate()`), breaking the consumer's signature verification without warning.
+- **No secret rotation overlap**: `/secret/change` is immediate; Svix/Stripe-style dual-secret grace periods are impossible, so rotation breaks verification until the consumer redeploys.
+- **No wildcard or prefix event subscriptions** (`ledger.*`), no event-type catalog endpoint.
+- **No automatic disabling** of endpoints failing for days (Stripe/Svix do this) and no customer notification when a webhook is finally marked `failed`.
+
+### 2.5 Operability & code health
+
+- **No metrics, no per-dependency split. (prod)** Only traces + logs. No delivery success rate, retry-queue depth, end-to-end latency, or per-endpoint error rate → incidents are debugged with SQL (cf. the recent `skip locked` / `active configs` firefighting in #147, #150). Worse, outbound delivery latency is not attributed: the "slow Deriv POSTs" turned out to be Webhooks→Xano outbound calls, misdiagnosed as internal Ledger latency. Dashboards must split by `service.name`, route, and external dependency.
+- **Health checks are no-ops**: server `/_healthcheck` returns an empty 200 with no DB check; the worker healthcheck logs `health check OK` at *Info* level on every probe (log spam).
+- **Mixed dependency generations**: `go-libs/v2` everywhere with `go-libs/v5` bolted on for audit only; `logrus` + go-libs logging coexist; `pkg/errors` is deprecated.
+- **Package layout**: the root `pkg` package (`webhooks`) is a grab-bag of domain model + HTTP delivery + backoff contract; the generated Speakeasy SDK (~100 files) is vendored in-tree with a `replace`, inflating the module and the diff noise.
+- **Handler style**: deeply nested `if err == nil { … } else { … }` blocks ([pkg/server/test.go](pkg/server/test.go)), repeated response-encoding boilerplate, no `http.MaxBytesReader` on request bodies.
+- **Docs drift**: this README previously documented "3 starting modes" and stale defaults; `docs/` is good but not linked from anywhere.
+
+---
+
+## 3. Improvement plan
+
+Phased so that each step ships independently and de-risks the next one. Within a phase, items are ordered by value/effort.
+
+### Phase 0 — Safety net (1 sprint)
+
+Goal: observe before changing anything.
+
+1. **OTel metrics** (S): counters/histograms for `webhooks_delivery_total{status,event_type}`, `webhooks_delivery_duration_seconds`, `webhooks_retry_queue_depth` (gauge from a cheap `count(*) where status='to retry'`), `webhooks_consumer_lag`. Wire to the existing OTLP pipeline; build the Grafana dashboard + alerts (queue depth, failure rate).
+2. **Real health checks** (S): DB ping on `/_healthcheck`; drop the per-probe Info log in the worker handler.
+3. **Load test harness** (M): a reproducible benchmark (k6 or Go) simulating one slow endpoint among N, to quantify the head-of-line problem and validate Phase 2.
+
+### Phase 1 — Stop the retry storms (1 sprint, **highest ROI**, mostly no schema change)
+
+These directly kill the [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) failure mode and the AWS cost bleed. Ship these first.
+
+1. **Terminal 4xx classification** (S): in `MakeAttempt`, mark `4xx` (except `408`/`429`) as `failed` immediately instead of `to retry`. Honor `Retry-After` for `429`. Kills the bulk of every observed storm (403/404/405 were the top error codes).
+2. **Circuit breaker + max-attempt cap** (M): per-config, after X consecutive failures stop claiming for a cooldown; hard-cap attempts (e.g. 15) independent of `--abort-after`. Lower the default `--abort-after` from 30d (720 retries) to something sane (e.g. 72h). Auto-disable endpoints failing > N days and flag them.
+3. **Retention / compaction of `attempts`** (M): scheduled purge of `success` (30d) and `failed` (90d) rows + reclaim orphaned `to retry` for deleted/inactive configs → `cancelled`. This is the change that produced the **~$39k/yr** cross-AZ saving; make it permanent and automatic instead of a manual one-off.
+4. **Per-dependency observability** (S): the Phase 0 metrics, split by `service.name` / route / outbound dependency so the next Tenora/Paynovate/Deriv case is caught from a dashboard, not 24h later by AWS billing.
+
+### Phase 1b — Security & correctness quick wins (1–2 sprints, no schema change)
+
+1. **SSRF guard** (M): dedicated `http.Client` for deliveries with `CheckRedirect` disabled (or re-validated per hop), a dialer-level deny-list of private/link-local/loopback ranges (validate the *resolved* IP, not the hostname, to kill DNS rebinding), and an `https`-only policy with an env escape hatch for on-prem/dev. Validate at config creation *and* at send time.
+2. **Bound response reads** (S): `io.LimitReader(resp.Body, 64<<10)` in `MakeAttempt`; persist a truncated body excerpt on failure (useful for the future deliveries API).
+3. **Stop leaking secrets** (M): redact `secret` from list/get responses (keep it on create/rotate only — breaking change to coordinate with SDK/fctl); stop snapshotting the secret inside `attempts.config` (strip it before insert; the retry path re-reads it from `configs`).
+4. **Add jitter to backoff** (S): full jitter (`rand(0, delay)`) to de-synchronize retry herds onto recovering endpoints.
+5. **Transactional retry processing** (M): wrap `InsertOneAttempt` + `UpdateAttemptsStatus` in one transaction; make `UpdateAttemptsStatus` a single `UPDATE … RETURNING` (drop the pre-SELECT).
+6. **Fix graceful shutdown** (M): replace `time.Sleep` with `select { case <-ctx.Done(); case <-ticker.C }`, run the loop off the fx lifecycle context, remove the `default:` escape in `Stop`, drain the pond pool with a deadline.
+7. **API correctness** (S): `UpdateOneConfig` checks existence (404) and bumps `updated_at`; reject secret regeneration on PUT unless explicitly requested.
+
+### Phase 2 — Delivery pipeline redesign (2–3 sprints, schema change)
+
+The structural fix for head-of-line blocking, duplicates, and the convoluted claim query. Target model:
+
+```
+events ──▶ consumer: INSERT deliveries (outbox) ──▶ ACK immediately
+                              │
+              dispatcher pool (same claim pattern,
+              but on a one-row-per-delivery table)
+                              │
+                        HTTP send ──▶ append-only delivery_attempts
+```
+
+1. **Introduce a `deliveries` table** (one row per event×config): `id`, `config_id` (FK), `event_id`, `event_type`, `payload`, `status (pending|delivering|succeeded|failed|cancelled)`, `attempt_count`, `next_attempt_at`, timestamps. Add `UNIQUE (event_id, config_id)` → **idempotent broker redelivery for free**. Keep `delivery_attempts` as an append-only log (id, delivery_id, status_code, error, duration, response excerpt).
+2. **Consumer becomes an outbox writer**: on message receipt, insert `pending` deliveries for all matching configs in one statement (`ON CONFLICT DO NOTHING`), ack. No HTTP on the hot path → consumer throughput decoupled from endpoint health; per-message work is one SELECT + one INSERT.
+3. **Dispatcher replaces the Retrier**: same `FOR UPDATE SKIP LOCKED` claim, but now a trivial `WHERE status='pending' AND next_attempt_at <= now() ORDER BY next_attempt_at LIMIT $n` on an FK-indexed table — no JSONB join, no `NOT EXISTS` anti-join, no multi-row status smearing. First attempts and retries share one code path.
+4. **Per-endpoint fairness & circuit breaking**: cap concurrent in-flight deliveries per config; after X consecutive failures open a circuit (skip claims for that config for a cooldown), and auto-disable + flag configs failing for > N days.
+5. **Migration strategy**: dual-write window — new code path behind a flag, backfill `to retry` attempts into `deliveries`, keep the legacy retrier reading the old table until drained, then drop the old claim machinery. The e2e suite plus the Phase 0 load test gate the cutover.
+
+### Phase 3 — Data lifecycle hardening (1 sprint, after Phase 2)
+
+Phase 1 ships a retention job on the legacy `attempts` table; this phase makes it first-class on the new model.
+
+1. **Retention/archival**: purge (or archive to object storage) `succeeded` deliveries after 30d and `failed` after 90d (configurable); attempts follow their delivery via `ON DELETE CASCADE`.
+2. **Payload cap** (e.g. 1 MiB) validated at ingestion.
+3. **Optional**: monthly partitioning of `delivery_attempts` by `created_at` if volume warrants it (cheap drops instead of `DELETE` churn → less cross-AZ traffic).
+
+### Phase 4 — API & product (1–2 sprints, parallelizable with Phase 3)
+
+1. **Deliveries API**: `GET /deliveries?config_id=&status=&cursor=` and `GET /deliveries/{id}/attempts` — gives support and customers visibility.
+2. **Manual replay**: `POST /deliveries/{id}/retry` (and bulk per config) — the #1 support request for any webhook system.
+3. **Real pagination** on `GET /configs` (bunpaginate is already a dependency).
+4. **Dual-secret rotation**: `/secret/change` keeps the previous secret valid for a grace period; sign with the new, send both signatures space-separated (the `Verify` helper already iterates multiple signatures).
+5. **Wildcard event types** (`ledger.*`) + `GET /event-types` catalog.
+6. **OpenAPI/SDK sync** for all of the above.
+
+### Phase 5 — Code health (continuous)
+
+1. Migrate fully to `go-libs/v5`; drop `logrus` and `pkg/errors` (use `fmt.Errorf`/`errors.Join`).
+2. Restructure: `internal/{api,delivery,storage,signing}` with a slim public `pkg/` (model + `security` verification helper, which customers may import); move the generated SDK out of the main module.
+3. Flatten handler error handling (early returns), shared `respondJSON`/`respondError` helpers, `http.MaxBytesReader` on request bodies.
+4. Unit tests for the dispatcher state machine and backoff (table-driven), keeping ginkgo for e2e.
+
+### Sequencing summary
+
+| Phase | Theme | Risk addressed | Effort |
+|-------|-------|----------------|--------|
+| 0 | Metrics & health | Flying blind | ~1 sprint |
+| **1** | **Stop retry storms (terminal 4xx, circuit breaker, retention, per-dep metrics)** | **Retry storms, ~$39k/yr cross-AZ cost, undetected dead endpoints** | **~1 sprint** |
+| 1b | Security/correctness quick wins | SSRF, secret leaks, dup retries, shutdown | 1–2 sprints |
+| 2 | Outbox + deliveries model | Head-of-line blocking, duplicates, claim complexity | 2–3 sprints |
+| 3 | Retention hardening | Unbounded growth (new model) | ~1 sprint |
+| 4 | Deliveries API, replay, rotation | Supportability, product parity | 1–2 sprints |
+| 5 | Code modernization | Maintenance drag | continuous |
+
+> **If you do only one thing this quarter:** Phase 1. Terminal-4xx + circuit breaker + automatic retention would have prevented every incident in the [§2.0](#20-the-core-problem-retry-storm--backlog-amplification-prod) table and the recurring AWS cost spikes.
+
+---
+
+## 4. Development
 
 Run the linters:
 ```
@@ -24,54 +303,28 @@ Run the tests:
 earthly -P +tests
 ```
 
-## Usage
+### Usage
+
 ```
 Usage:
   webhooks [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  serve       Run webhooks server
-  version     Get webhooks version
+  serve       Run webhooks server (add --worker to embed the worker)
   worker      Run webhooks worker
+  version     Get webhooks version
 
-Flags:
-      --abort-after duration                          consider a webhook as failed after retrying it for this duration. (default 720h0m0s)
-      --debug                                         Debug mode
-  -h, --help                                          help for webhooks
-      --kafka-topics strings                          Kafka topics (default [default])
-      --listen string                                 server HTTP bind address (default ":8080")
-      --log-level string                              Log level (default "info")
-      --max-backoff-delay duration                    maximum backoff delay (default 1h0m0s)
-      --min-backoff-delay duration                    minimum backoff delay (default 1m0s)
-      --otel-resource-attributes strings              Additional OTLP resource attributes
-      --otel-service-name string                      OpenTelemetry service name
-      --otel-traces                                   Enable OpenTelemetry traces support
-      --otel-traces-batch                             Use OpenTelemetry batching
-      --otel-traces-exporter string                   OpenTelemetry traces exporter (default "stdout")
-      --otel-traces-exporter-jaeger-endpoint string   OpenTelemetry traces Jaeger exporter endpoint
-      --otel-traces-exporter-jaeger-password string   OpenTelemetry traces Jaeger exporter password
-      --otel-traces-exporter-jaeger-user string       OpenTelemetry traces Jaeger exporter user
-      --otel-traces-exporter-otlp-endpoint string     OpenTelemetry traces grpc endpoint
-      --otel-traces-exporter-otlp-insecure            OpenTelemetry traces grpc insecure
-      --otel-traces-exporter-otlp-mode string         OpenTelemetry traces OTLP exporter mode (grpc|http) (default "grpc")
-      --publisher-http-enabled                        Sent write event to http endpoint
-      --publisher-kafka-broker strings                Kafka address is kafka enabled (default [localhost:9092])
-      --publisher-kafka-enabled                       Publish write events to kafka
-      --publisher-kafka-sasl-enabled                  Enable SASL authentication on kafka publisher
-      --publisher-kafka-sasl-mechanism string         SASL authentication mechanism
-      --publisher-kafka-sasl-password string          SASL password
-      --publisher-kafka-sasl-scram-sha-size int       SASL SCRAM SHA size (default 512)
-      --publisher-kafka-sasl-username string          SASL username
-      --publisher-kafka-tls-enabled                   Enable TLS to connect on kafka
-      --publisher-nats-client-id string               Nats client ID
-      --publisher-nats-enabled                        Publish write events to nats
-      --publisher-nats-max-reconnect int              Nats: set the maximum number of reconnect attempts. (default 30)
-      --publisher-nats-reconnect-wait duration        Nats: the wait time between reconnect attempts. (default 2s)
-      --publisher-nats-url string                     Nats url
-      --publisher-topic-mapping strings               Define mapping between internal event types and topics
-      --retry-period duration                         worker retry period (default 1m0s)
-      --storage-postgres-conn-string string           Postgres connection string (default "postgresql://webhooks:webhooks@127.0.0.1/webhooks?sslmode=disable")
-      --worker                                        Enable worker on server
+Key flags:
+      --listen string                        HTTP bind address (default ":8080")
+      --worker                               Enable worker inside the server process
+      --kafka-topics strings                 Topics to consume (default [default])
+      --retry-period duration                Retry poll period (default 3s)
+      --retry-batch-size int                 Webhook IDs claimed per tick (default 50)
+      --min-backoff-delay duration           Minimum backoff delay (default 1m)
+      --max-backoff-delay duration           Maximum backoff delay (default 1h)
+      --abort-after duration                 Mark failed after retrying this long (default 720h)
+      --auto-migrate                         Run DB migrations on startup
+      --storage-postgres-conn-string string  Postgres connection string
 ```
+
+Further reading: [docs/architecture.md](docs/architecture.md), [docs/retry-mechanism.md](docs/retry-mechanism.md), [docs/message-processing.md](docs/message-processing.md), [docs/security.md](docs/security.md).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Key design consequence: **the current state of a delivery is smeared across mult
 
 1. **Stale recovery** (≤ once/min): attempts stuck in `retrying` > 5 min (crashed worker) are reset to `to retry`.
 2. **Atomic claim** ([pkg/storage/postgres/postgres.go](pkg/storage/postgres/postgres.go) `FindWebhookIDsToRetry`): a CTE selects up to `--retry-batch-size` (default 50) distinct `webhook_id`s whose oldest due attempt is ready, joins `configs` on `attempts.config->>'id'` to keep only active configs, locks rows with `FOR UPDATE SKIP LOCKED` (multi-worker safe), and flips them to `retrying`.
-3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, re-send with `MakeAttempt` at `retry_attempt + 1`, insert the new attempt, then update the claimed rows to the outcome status.
+3. **Parallel processing** via a bounded `pond` pool: for each webhook, re-read the `retrying` attempts, re-send with `MakeAttempt` at `retry_attempt + 1`, insert the new attempt, then terminalize the claimed rows. If the new attempt is retryable, only the newly inserted row stays in `to retry`.
 4. Sleep, repeat.
 
 Backoff is exponential without jitter ([pkg/backoff/exponential.go](pkg/backoff/exponential.go)): `min-backoff-delay` (1m) doubling up to `max-backoff-delay` (1h), aborting to `failed` once cumulative elapsed time exceeds `--abort-after` (default 72h) or `--max-attempts` is reached (default 15 attempts).

--- a/cmd/flag/flags.go
+++ b/cmd/flag/flags.go
@@ -38,7 +38,7 @@ const (
 var (
 	DefaultRetryPeriod    = 3 * time.Second
 	DefaultRetryBatchSize = 50
-	DefaultAbortAfter     = 72 * time.Hour
+	DefaultAbortAfter     = 10 * time.Hour
 	DefaultMaxAttempts    = 15
 
 	DefaultRetentionPeriod       = time.Hour

--- a/cmd/flag/flags.go
+++ b/cmd/flag/flags.go
@@ -19,6 +19,10 @@ const (
 	MinBackoffDelay = "min-backoff-delay"
 	MaxBackoffDelay = "max-backoff-delay"
 
+	RetentionPeriod       = "retention-period"
+	RetentionSuccessDelay = "retention-success-delay"
+	RetentionFailedDelay  = "retention-failed-delay"
+
 	KafkaTopics = "kafka-topics"
 	AutoMigrate = "auto-migrate"
 )
@@ -36,6 +40,10 @@ var (
 	DefaultRetryBatchSize = 50
 	DefaultAbortAfter     = 72 * time.Hour
 	DefaultMaxAttempts    = 15
+
+	DefaultRetentionPeriod       = time.Hour
+	DefaultRetentionSuccessDelay = 30 * 24 * time.Hour
+	DefaultRetentionFailedDelay  = 90 * 24 * time.Hour
 )
 
 func Init(flagSet *pflag.FlagSet) {
@@ -52,5 +60,10 @@ func Init(flagSet *pflag.FlagSet) {
 	flagSet.Int(MaxAttempts, DefaultMaxAttempts, "hard cap on delivery attempts per webhook (0 disables the cap, leaving abort-after as the only bound)")
 	flagSet.Duration(MinBackoffDelay, time.Minute, "minimum backoff delay")
 	flagSet.Duration(MaxBackoffDelay, time.Hour, "maximum backoff delay")
+
+	flagSet.Duration(RetentionPeriod, DefaultRetentionPeriod, "interval between attempts-table cleanup runs")
+	flagSet.Duration(RetentionSuccessDelay, DefaultRetentionSuccessDelay, "retain 'success' attempts for this long before purging (0 disables)")
+	flagSet.Duration(RetentionFailedDelay, DefaultRetentionFailedDelay, "retain 'failed' attempts for this long before purging (0 disables)")
+
 	flagSet.Bool(AutoMigrate, false, "auto migrate database")
 }

--- a/cmd/flag/flags.go
+++ b/cmd/flag/flags.go
@@ -12,9 +12,10 @@ const (
 	Listen   = "listen"
 	Worker   = "worker"
 
-	RetryPeriod    = "retry-period"
-	RetryBatchSize = "retry-batch-size"
-	AbortAfter     = "abort-after"
+	RetryPeriod     = "retry-period"
+	RetryBatchSize  = "retry-batch-size"
+	AbortAfter      = "abort-after"
+	MaxAttempts     = "max-attempts"
 	MinBackoffDelay = "min-backoff-delay"
 	MaxBackoffDelay = "max-backoff-delay"
 
@@ -33,6 +34,8 @@ const (
 var (
 	DefaultRetryPeriod    = 3 * time.Second
 	DefaultRetryBatchSize = 50
+	DefaultAbortAfter     = 72 * time.Hour
+	DefaultMaxAttempts    = 15
 )
 
 func Init(flagSet *pflag.FlagSet) {
@@ -45,7 +48,8 @@ func Init(flagSet *pflag.FlagSet) {
 
 	flagSet.StringSlice(KafkaTopics, []string{DefaultKafkaTopic}, "Kafka topics")
 
-	flagSet.Duration(AbortAfter, 30*24*time.Hour, "consider a webhook as failed after retrying it for this duration.")
+	flagSet.Duration(AbortAfter, DefaultAbortAfter, "consider a webhook as failed after retrying it for this duration.")
+	flagSet.Int(MaxAttempts, DefaultMaxAttempts, "hard cap on delivery attempts per webhook (0 disables the cap, leaving abort-after as the only bound)")
 	flagSet.Duration(MinBackoffDelay, time.Minute, "minimum backoff delay")
 	flagSet.Duration(MaxBackoffDelay, time.Hour, "maximum backoff delay")
 	flagSet.Bool(AutoMigrate, false, "auto migrate database")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -58,8 +58,10 @@ func serve(cmd *cobra.Command, _ []string) error {
 		}),
 		auth.FXModuleFromFlags(cmd),
 		publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
-		otlpmetrics.FXModuleFromFlags(cmd),
 		postgres.NewModule(*connectionOptions, service.IsDebug(cmd)),
+		// Registered after postgres so metrics stop (and flush DB-backed
+		// gauges) before the database connection is closed.
+		otlpmetrics.FXModuleFromFlags(cmd),
 		innerotlp.HttpClientModule(),
 		server.FXModuleFromFlags(cmd, listen, service.IsDebug(cmd)),
 		licence.FXModuleFromFlags(cmd, ServiceName),

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/formancehq/go-libs/v2/aws/iam"
 	"github.com/formancehq/go-libs/v2/otlp"
+	"github.com/formancehq/go-libs/v2/otlp/otlpmetrics"
 	"github.com/formancehq/go-libs/v2/otlp/otlptraces"
 	"github.com/formancehq/go-libs/v2/publish"
 
@@ -30,6 +31,7 @@ func newServeCommand() *cobra.Command {
 	}
 	otlp.AddFlags(ret.Flags())
 	otlptraces.AddFlags(ret.Flags())
+	otlpmetrics.AddFlags(ret.Flags())
 	publish.AddFlags(ServiceName, ret.Flags())
 	auth.AddFlags(ret.Flags())
 	flag.Init(ret.Flags())
@@ -56,6 +58,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 		}),
 		auth.FXModuleFromFlags(cmd),
 		publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
+		otlpmetrics.FXModuleFromFlags(cmd),
 		postgres.NewModule(*connectionOptions, service.IsDebug(cmd)),
 		innerotlp.HttpClientModule(),
 		server.FXModuleFromFlags(cmd, listen, service.IsDebug(cmd)),

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -83,6 +83,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 			retryBatchSize,
 			service.IsDebug(cmd),
 			topics,
+			retentionConfigFromFlags(cmd),
 		))
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -68,6 +68,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 		minBackOffDelay, _ := cmd.Flags().GetDuration(flag.MinBackoffDelay)
 		maxBackOffDelay, _ := cmd.Flags().GetDuration(flag.MaxBackoffDelay)
 		abortAfter, _ := cmd.Flags().GetDuration(flag.AbortAfter)
+		maxAttempts, _ := cmd.Flags().GetInt(flag.MaxAttempts)
 		topics, _ := cmd.Flags().GetStringSlice(flag.KafkaTopics)
 
 		options = append(options, worker.StartModule(
@@ -77,6 +78,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 				minBackOffDelay,
 				maxBackOffDelay,
 				abortAfter,
+				maxAttempts,
 			),
 			retryBatchSize,
 			service.IsDebug(cmd),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -60,6 +60,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 	maxAttempts, _ := cmd.Flags().GetInt(flag.MaxAttempts)
 	topics, _ := cmd.Flags().GetStringSlice(flag.KafkaTopics)
 	listen, _ := cmd.Flags().GetString(flag.Listen)
+	retention := retentionConfigFromFlags(cmd)
 
 	return service.New(
 		cmd.OutOrStdout(),
@@ -84,6 +85,18 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 			retryBatchSize,
 			service.IsDebug(cmd),
 			topics,
+			retention,
 		),
 	).Run(cmd)
+}
+
+func retentionConfigFromFlags(cmd *cobra.Command) worker.RetentionConfig {
+	period, _ := cmd.Flags().GetDuration(flag.RetentionPeriod)
+	successDelay, _ := cmd.Flags().GetDuration(flag.RetentionSuccessDelay)
+	failedDelay, _ := cmd.Flags().GetDuration(flag.RetentionFailedDelay)
+	return worker.RetentionConfig{
+		Period:       period,
+		SuccessDelay: successDelay,
+		FailedDelay:  failedDelay,
+	}
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/formancehq/go-libs/v2/bun/bunconnect"
 	"github.com/formancehq/go-libs/v2/licence"
 
+	"github.com/formancehq/go-libs/v2/otlp/otlpmetrics"
 	"github.com/formancehq/go-libs/v2/otlp/otlptraces"
 
 	"github.com/formancehq/go-libs/v2/httpserver"
@@ -35,6 +36,7 @@ func newWorkerCommand() *cobra.Command {
 	}
 	otlp.AddFlags(ret.Flags())
 	otlptraces.AddFlags(ret.Flags())
+	otlpmetrics.AddFlags(ret.Flags())
 	publish.AddFlags(ServiceName, ret.Flags())
 	auth.AddFlags(ret.Flags())
 	flag.Init(ret.Flags())
@@ -73,6 +75,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 		}),
 		otlp.FXModuleFromFlags(cmd),
 		otlptraces.FXModuleFromFlags(cmd),
+		otlpmetrics.FXModuleFromFlags(cmd),
 		worker.StartModule(
 			cmd,
 			retryPeriod,

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -57,6 +57,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 	minBackOffDelay, _ := cmd.Flags().GetDuration(flag.MinBackoffDelay)
 	maxBackOffDelay, _ := cmd.Flags().GetDuration(flag.MaxBackoffDelay)
 	abortAfter, _ := cmd.Flags().GetDuration(flag.AbortAfter)
+	maxAttempts, _ := cmd.Flags().GetInt(flag.MaxAttempts)
 	topics, _ := cmd.Flags().GetStringSlice(flag.KafkaTopics)
 	listen, _ := cmd.Flags().GetString(flag.Listen)
 
@@ -78,6 +79,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 				minBackOffDelay,
 				maxBackOffDelay,
 				abortAfter,
+				maxAttempts,
 			),
 			retryBatchSize,
 			service.IsDebug(cmd),

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -149,7 +149,8 @@ This ensures no attempt is permanently stuck. The 5-minute window is chosen to b
 | `--retry-batch-size` | `50` | Number of distinct webhook IDs claimed per tick |
 | `--min-backoff-delay` | `1m` | Minimum delay before retrying a failed attempt |
 | `--max-backoff-delay` | `1h` | Maximum delay between retries (exponential backoff) |
-| `--abort-after` | `30d` | Stop retrying after this duration and mark as `failed` |
+| `--abort-after` | `10h` | Stop retrying after this duration and mark as `failed` |
+| `--max-attempts` | `15` | Stop retrying after this many delivery attempts; with nominal backoff this is about 9h03 |
 
 ## Database Indexes
 
@@ -175,6 +176,10 @@ WHERE status = 'retrying';
 CREATE INDEX idx_attempts_retrying_recovery
 ON attempts (updated_at)
 WHERE status = 'retrying';
+
+-- Speeds up fetching the first attempt timestamp for retry-window checks
+CREATE INDEX CONCURRENTLY idx_attempts_first_attempt_lookup
+ON attempts (webhook_id, created_at);
 ```
 
 ## HTTP Client
@@ -183,7 +188,7 @@ The HTTP client used for webhook delivery has a **30-second timeout** (`pkg/otlp
 
 ## Backoff Strategy
 
-Uses exponential backoff with jitter (see `pkg/backoff/exponential.go`):
+Uses exponential backoff without jitter (see `pkg/backoff/exponential.go`):
 
 - Each retry attempt increases the delay exponentially, starting from `--min-backoff-delay`.
 - The delay is capped at `--max-backoff-delay`.

--- a/docs/retry-mechanism.md
+++ b/docs/retry-mechanism.md
@@ -45,7 +45,7 @@ The `Retrier` runs in a single goroutine with the following loop:
    - Unmarshal the payload from the most recent attempt
    - Execute the HTTP call (`MakeAttempt`) with a 30-second timeout
    - Insert a new attempt record with the result
-   - Update only the claimed (`retrying`) attempts to the final status
+   - Terminalize the claimed (`retrying`) attempts; if the new result is retryable, only the newly inserted attempt remains in `to retry`
    - The worker waits for all goroutines to complete before sleeping
 4. **Sleep** -- Wait `--retry-period` (default: 3 seconds), then repeat.
 
@@ -113,7 +113,7 @@ Oldest retries are prioritized per webhook with the `NOT EXISTS` check, then glo
 
 ### Status Scoping
 
-`UpdateAttemptsStatus` only modifies attempts in `retrying` status. Historical attempts (`success`, `failed`) are never overwritten. This ensures:
+`UpdateAttemptsStatus` only modifies attempts in `retrying` status. Historical attempts (`success`, `failed`) are never overwritten. When a retry still needs another retry, the claimed rows are marked `failed` and the newly inserted attempt carries the next `to retry` state. This ensures:
 - Accurate audit trail per attempt
 - No accidental overwrites from concurrent Kafka messages creating new attempts for the same webhook
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ replace github.com/formancehq/webhooks/pkg/client => ./pkg/client
 require (
 	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/alitto/pond v1.9.2
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/formancehq/go-libs/v2 v2.2.5
 	github.com/formancehq/go-libs/v5 v5.1.1-0.20260522083443-d2a60ed2e0dd
 	github.com/formancehq/webhooks/pkg/client v0.0.0-00010101000000-000000000000
@@ -69,6 +68,7 @@ require (
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dnwe/otelsarama v0.0.0-20240308230250-9388d9d40bc0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/uptrace/bun/dialect/pgdialect v1.2.18
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.66.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/fx v1.24.0
 )
@@ -200,7 +201,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.41.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.41.0 // indirect
 	go.opentelemetry.io/otel/log v0.17.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/formancehq/webhooks/pkg/metrics"
 	"github.com/formancehq/webhooks/pkg/security"
 	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
@@ -104,18 +105,34 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 		req.Header.Set("formance-webhook-idempotency-key", idempotencyKey)
 	}
 
-	resp, err := httpClient.Do(req)
+	start := time.Now()
+	resp, doErr := httpClient.Do(req)
+
+	attempt, err := classifyResponse(ctx, resp, doErr, retryPolicy, attemptNb, ts, Attempt{
+		ID:           id,
+		WebhookID:    webhookID,
+		Config:       cfg,
+		Payload:      string(payload),
+		RetryAttempt: attemptNb,
+	})
 	if err != nil {
+		return Attempt{}, err
+	}
+
+	metrics.RecordDelivery(ctx, attempt.Status, attempt.StatusCode, time.Since(start))
+	return attempt, nil
+}
+
+// classifyResponse turns the result of the delivery HTTP call into a persisted
+// Attempt with its final status. base carries the identity fields already set by
+// the caller; doErr is the transport error (if any).
+func classifyResponse(ctx context.Context, resp *http.Response, doErr error, retryPolicy BackoffPolicy, attemptNb int, ts time.Time, base Attempt) (Attempt, error) {
+	attempt := base
+
+	if doErr != nil {
 		// Transport/timeout failure — return a retryable attempt so the record is
 		// persisted and the retry loop picks it up instead of losing the event.
-		attempt := Attempt{
-			ID:           id,
-			WebhookID:    webhookID,
-			Config:       cfg,
-			Payload:      string(payload),
-			StatusCode:   0,
-			RetryAttempt: attemptNb,
-		}
+		attempt.StatusCode = 0
 		delay, delayErr := retryPolicy.GetRetryDelay(attemptNb)
 		if delayErr != nil {
 			attempt.Status = StatusAttemptFailed
@@ -139,14 +156,7 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 	}
 	logging.FromContext(ctx).Debugf("webhooks.MakeAttempt: server response body: %s", string(body))
 
-	attempt := Attempt{
-		ID:           id,
-		WebhookID:    webhookID,
-		Config:       cfg,
-		Payload:      string(payload),
-		StatusCode:   resp.StatusCode,
-		RetryAttempt: attemptNb,
-	}
+	attempt.StatusCode = resp.StatusCode
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		attempt.Status = StatusAttemptSuccess

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -88,13 +88,39 @@ type Attempt struct {
 	NextRetryAfter time.Time `json:"nextRetryAfter,omitempty" bun:"next_retry_after,nullzero"`
 }
 
-func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy BackoffPolicy, id, webhookID string, attemptNb int, cfg Config, idempotencyKey string, payload []byte, isTest bool) (Attempt, error) {
+type attemptOptions struct {
+	firstAttemptAt time.Time
+}
+
+type AttemptOption func(*attemptOptions)
+
+// WithFirstAttemptAt lets retry callers enforce abort-after against the real
+// elapsed time since the first delivery attempt, including prior Retry-After
+// delays.
+func WithFirstAttemptAt(firstAttemptAt time.Time) AttemptOption {
+	return func(opts *attemptOptions) {
+		if !firstAttemptAt.IsZero() {
+			opts.firstAttemptAt = firstAttemptAt.UTC()
+		}
+	}
+}
+
+func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy BackoffPolicy, id, webhookID string, attemptNb int, cfg Config, idempotencyKey string, payload []byte, isTest bool, opts ...AttemptOption) (Attempt, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.Endpoint, bytes.NewBuffer(payload))
 	if err != nil {
 		return Attempt{}, errors.Wrap(err, "http.NewRequestWithContext")
 	}
 
+	options := attemptOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	requestTime := time.Now().UTC()
+	if options.firstAttemptAt.IsZero() {
+		options.firstAttemptAt = requestTime
+	}
+
 	timestamp := requestTime.Unix()
 	signature, err := security.Sign(webhookID, timestamp, cfg.Secret, payload)
 	if err != nil {
@@ -115,7 +141,7 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 	resp, doErr := httpClient.Do(req)
 	decisionTime := time.Now().UTC()
 
-	attempt, err := classifyResponse(ctx, resp, doErr, retryPolicy, attemptNb, decisionTime, Attempt{
+	attempt, err := classifyResponse(ctx, resp, doErr, retryPolicy, attemptNb, decisionTime, options.firstAttemptAt, Attempt{
 		ID:           id,
 		WebhookID:    webhookID,
 		Config:       cfg,
@@ -133,7 +159,7 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 // classifyResponse turns the result of the delivery HTTP call into a persisted
 // Attempt with its final status. base carries the identity fields already set by
 // the caller; doErr is the transport error (if any).
-func classifyResponse(ctx context.Context, resp *http.Response, doErr error, retryPolicy BackoffPolicy, attemptNb int, now time.Time, base Attempt) (Attempt, error) {
+func classifyResponse(ctx context.Context, resp *http.Response, doErr error, retryPolicy BackoffPolicy, attemptNb int, now, firstAttemptAt time.Time, base Attempt) (Attempt, error) {
 	attempt := base
 
 	if doErr != nil {
@@ -145,8 +171,13 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 			attempt.Status = StatusAttemptFailed
 			return attempt, nil
 		}
+		nextRetryAfter := now.Add(delay)
+		if err := limitRetryWindow(retryPolicy, firstAttemptAt, nextRetryAfter); err != nil {
+			attempt.Status = StatusAttemptFailed
+			return attempt, nil
+		}
 		attempt.Status = StatusAttemptToRetry
-		attempt.NextRetryAfter = now.Add(delay)
+		attempt.NextRetryAfter = nextRetryAfter
 		return attempt, nil
 	}
 
@@ -198,7 +229,22 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 		delay = retryAfter
 	}
 
+	nextRetryAfter := now.Add(delay)
+	if err := limitRetryWindow(retryPolicy, firstAttemptAt, nextRetryAfter); err != nil {
+		attempt.Status = StatusAttemptFailed
+		return attempt, nil
+	}
 	attempt.Status = StatusAttemptToRetry
-	attempt.NextRetryAfter = now.Add(delay)
+	attempt.NextRetryAfter = nextRetryAfter
 	return attempt, nil
+}
+
+func limitRetryWindow(retryPolicy BackoffPolicy, firstAttemptAt, nextRetryAfter time.Time) error {
+	if firstAttemptAt.IsZero() {
+		return nil
+	}
+	if limiter, ok := retryPolicy.(RetryWindowLimiter); ok {
+		return limiter.LimitRetryWindow(nextRetryAfter.Sub(firstAttemptAt))
+	}
+	return nil
 }

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -94,8 +94,8 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 		return Attempt{}, errors.Wrap(err, "http.NewRequestWithContext")
 	}
 
-	ts := time.Now().UTC()
-	timestamp := ts.Unix()
+	requestTime := time.Now().UTC()
+	timestamp := requestTime.Unix()
 	signature, err := security.Sign(webhookID, timestamp, cfg.Secret, payload)
 	if err != nil {
 		return Attempt{}, errors.Wrap(err, "security.Sign")
@@ -113,8 +113,9 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 
 	start := time.Now()
 	resp, doErr := httpClient.Do(req)
+	decisionTime := time.Now().UTC()
 
-	attempt, err := classifyResponse(ctx, resp, doErr, retryPolicy, attemptNb, ts, Attempt{
+	attempt, err := classifyResponse(ctx, resp, doErr, retryPolicy, attemptNb, decisionTime, Attempt{
 		ID:           id,
 		WebhookID:    webhookID,
 		Config:       cfg,
@@ -132,7 +133,7 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 // classifyResponse turns the result of the delivery HTTP call into a persisted
 // Attempt with its final status. base carries the identity fields already set by
 // the caller; doErr is the transport error (if any).
-func classifyResponse(ctx context.Context, resp *http.Response, doErr error, retryPolicy BackoffPolicy, attemptNb int, ts time.Time, base Attempt) (Attempt, error) {
+func classifyResponse(ctx context.Context, resp *http.Response, doErr error, retryPolicy BackoffPolicy, attemptNb int, now time.Time, base Attempt) (Attempt, error) {
 	attempt := base
 
 	if doErr != nil {
@@ -145,7 +146,7 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 			return attempt, nil
 		}
 		attempt.Status = StatusAttemptToRetry
-		attempt.NextRetryAfter = ts.Add(delay)
+		attempt.NextRetryAfter = now.Add(delay)
 		return attempt, nil
 	}
 
@@ -185,7 +186,7 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 	// Respect an explicit Retry-After (429/503) when it asks us to wait longer
 	// than our computed backoff, but never let endpoint-controlled delays bypass
 	// the retry policy window.
-	if retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"), ts); ok && retryAfter > delay {
+	if retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"), now); ok && retryAfter > delay {
 		if limiter, ok := retryPolicy.(RetryDelayLimiter); ok {
 			var limitErr error
 			retryAfter, limitErr = limiter.LimitRetryDelay(attemptNb, retryAfter)
@@ -198,6 +199,6 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 	}
 
 	attempt.Status = StatusAttemptToRetry
-	attempt.NextRetryAfter = ts.Add(delay)
+	attempt.NextRetryAfter = now.Add(delay)
 	return attempt, nil
 }

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/formancehq/go-libs/v2/logging"
@@ -13,6 +15,49 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
 )
+
+// maxResponseBody caps how much of an endpoint's response we read. The body is
+// only used for debug logging / diagnostics, so there is no reason to let a
+// malicious or buggy endpoint stream an unbounded payload into worker memory.
+const maxResponseBody = 64 << 10 // 64 KiB
+
+// isPermanentClientError reports whether an HTTP status code is a client error
+// that will never succeed on retry. Retrying these (wrong credentials, gone,
+// method not allowed, ...) only amplifies load — the root cause of the observed
+// retry storms. 408 (Request Timeout) and 429 (Too Many Requests) are explicitly
+// excluded: they are transient and worth retrying.
+func isPermanentClientError(statusCode int) bool {
+	if statusCode < http.StatusBadRequest || statusCode >= http.StatusInternalServerError {
+		return false
+	}
+	switch statusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return false
+	default:
+		return true
+	}
+}
+
+// parseRetryAfter interprets a Retry-After header (delay-seconds or HTTP-date)
+// relative to now. It returns false when the header is absent or unparseable.
+func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(header); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(header); err == nil {
+		if d := t.Sub(now); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
 
 const (
 	StatusAttemptSuccess  = "success"
@@ -88,7 +133,7 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 		}
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
 	if err != nil {
 		return Attempt{}, errors.Wrap(err, "io.ReadAll")
 	}
@@ -108,10 +153,23 @@ func MakeAttempt(ctx context.Context, httpClient *http.Client, retryPolicy Backo
 		return attempt, nil
 	}
 
+	// Permanent client errors will never succeed on retry — fail fast instead of
+	// retrying for the whole abort-after window.
+	if isPermanentClientError(resp.StatusCode) {
+		attempt.Status = StatusAttemptFailed
+		return attempt, nil
+	}
+
 	delay, err := retryPolicy.GetRetryDelay(attemptNb)
 	if err != nil {
 		attempt.Status = StatusAttemptFailed
 		return attempt, nil
+	}
+
+	// Respect an explicit Retry-After (429/503) when it asks us to wait longer
+	// than our computed backoff.
+	if retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"), ts); ok && retryAfter > delay {
+		delay = retryAfter
 	}
 
 	attempt.Status = StatusAttemptToRetry

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -39,8 +39,14 @@ func isPermanentClientError(statusCode int) bool {
 	}
 }
 
+// maxRetryAfterDelay clamps how far a Retry-After header can push the next
+// retry: the endpoint controls this value, so an absurd one must not park a
+// delivery years in the future.
+const maxRetryAfterDelay = 6 * time.Hour
+
 // parseRetryAfter interprets a Retry-After header (delay-seconds or HTTP-date)
-// relative to now. It returns false when the header is absent or unparseable.
+// relative to now, clamped to maxRetryAfterDelay. It returns false when the
+// header is absent or unparseable.
 func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 	header = strings.TrimSpace(header)
 	if header == "" {
@@ -50,11 +56,11 @@ func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 		if secs < 0 {
 			return 0, false
 		}
-		return time.Duration(secs) * time.Second, true
+		return min(time.Duration(secs)*time.Second, maxRetryAfterDelay), true
 	}
 	if t, err := http.ParseTime(header); err == nil {
 		if d := t.Sub(now); d > 0 {
-			return d, true
+			return min(d, maxRetryAfterDelay), true
 		}
 	}
 	return 0, false

--- a/pkg/attempt.go
+++ b/pkg/attempt.go
@@ -183,8 +183,17 @@ func classifyResponse(ctx context.Context, resp *http.Response, doErr error, ret
 	}
 
 	// Respect an explicit Retry-After (429/503) when it asks us to wait longer
-	// than our computed backoff.
+	// than our computed backoff, but never let endpoint-controlled delays bypass
+	// the retry policy window.
 	if retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"), ts); ok && retryAfter > delay {
+		if limiter, ok := retryPolicy.(RetryDelayLimiter); ok {
+			var limitErr error
+			retryAfter, limitErr = limiter.LimitRetryDelay(attemptNb, retryAfter)
+			if limitErr != nil {
+				attempt.Status = StatusAttemptFailed
+				return attempt, nil
+			}
+		}
 		delay = retryAfter
 	}
 

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -258,6 +258,35 @@ func TestMakeAttempt_RetryAfterCannotExceedAbortAfterWindow(t *testing.T) {
 	assert.True(t, attempt.NextRetryAfter.IsZero(), "Retry-After beyond abort-after must not schedule a retry")
 }
 
+func TestMakeAttempt_RetryAfterCannotExtendPastFirstAttemptWindow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7200")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-retry-after-first-attempt-window",
+		Active: true,
+	}
+
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(),
+		backoff.NewExponential(time.Second, time.Hour, 72*time.Hour, 15),
+		"attempt-id", "webhook-id", 12, cfg, "", []byte(`{"type":"test.event"}`), false,
+		webhooks.WithFirstAttemptAt(time.Now().UTC().Add(-71*time.Hour)),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptFailed, attempt.Status)
+	assert.True(t, attempt.NextRetryAfter.IsZero(), "Retry-After must not extend the real retry window past abort-after")
+}
+
 func TestMakeAttempt_ClampsAbsurdRetryAfter(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "99999999") // ~3 years

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -196,6 +196,34 @@ func TestMakeAttempt_HonorsRetryAfter(t *testing.T) {
 		"Retry-After (120s) should override the shorter backoff")
 }
 
+func TestMakeAttempt_RetryAfterCannotExceedAbortAfterWindow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "21600")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-retry-after-abort-after",
+		Active: true,
+	}
+
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(),
+		backoff.NewExponential(time.Second, time.Hour, 3*time.Second, 0),
+		"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptFailed, attempt.Status)
+	assert.True(t, attempt.NextRetryAfter.IsZero(), "Retry-After beyond abort-after must not schedule a retry")
+}
+
 func TestMakeAttempt_ClampsAbsurdRetryAfter(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "99999999") // ~3 years

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	webhooks "github.com/formancehq/webhooks/pkg"
+	"github.com/formancehq/webhooks/pkg/backoff"
 )
 
 type fixedBackoff struct {
@@ -83,6 +84,33 @@ func TestMakeAttempt_TransportError_MaxRetriesExceeded(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, webhooks.StatusAttemptFailed, attempt.Status)
+}
+
+func TestMakeAttempt_MaxAttemptsOneDoesNotScheduleRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-max-attempts-one",
+		Active: true,
+	}
+
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(),
+		backoff.NewExponential(time.Second, time.Minute, time.Hour, 1),
+		"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptFailed, attempt.Status)
+	assert.True(t, attempt.NextRetryAfter.IsZero(), "max-attempts=1 must not schedule a retry")
 }
 
 func TestMakeAttempt_StatusClassification(t *testing.T) {

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -167,3 +167,33 @@ func TestMakeAttempt_HonorsRetryAfter(t *testing.T) {
 	assert.GreaterOrEqual(t, attempt.NextRetryAfter.Sub(before), 110*time.Second,
 		"Retry-After (120s) should override the shorter backoff")
 }
+
+func TestMakeAttempt_ClampsAbsurdRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "99999999") // ~3 years
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-retry-after-clamp",
+		Active: true,
+	}
+
+	policy := &fixedBackoff{delay: 15 * time.Second}
+	before := time.Now().UTC()
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(), policy,
+		"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptToRetry, attempt.Status)
+	assert.LessOrEqual(t, attempt.NextRetryAfter.Sub(before), 7*time.Hour,
+		"an endpoint-controlled Retry-After must not park the delivery years in the future")
+}

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -84,3 +84,86 @@ func TestMakeAttempt_TransportError_MaxRetriesExceeded(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, webhooks.StatusAttemptFailed, attempt.Status)
 }
+
+func TestMakeAttempt_StatusClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantStatus string
+	}{
+		{"2xx success", http.StatusOK, webhooks.StatusAttemptSuccess},
+		{"201 success", http.StatusCreated, webhooks.StatusAttemptSuccess},
+		{"400 permanent", http.StatusBadRequest, webhooks.StatusAttemptFailed},
+		{"401 permanent", http.StatusUnauthorized, webhooks.StatusAttemptFailed},
+		{"403 permanent", http.StatusForbidden, webhooks.StatusAttemptFailed},
+		{"404 permanent", http.StatusNotFound, webhooks.StatusAttemptFailed},
+		{"405 permanent", http.StatusMethodNotAllowed, webhooks.StatusAttemptFailed},
+		{"408 retryable", http.StatusRequestTimeout, webhooks.StatusAttemptToRetry},
+		{"429 retryable", http.StatusTooManyRequests, webhooks.StatusAttemptToRetry},
+		{"500 retryable", http.StatusInternalServerError, webhooks.StatusAttemptToRetry},
+		{"503 retryable", http.StatusServiceUnavailable, webhooks.StatusAttemptToRetry},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			cfg := webhooks.Config{
+				ConfigUser: webhooks.ConfigUser{
+					Endpoint:   server.URL,
+					Secret:     webhooks.NewSecret(),
+					EventTypes: []string{"test.event"},
+				},
+				ID:     "cfg-status",
+				Active: true,
+			}
+
+			policy := &fixedBackoff{delay: 15 * time.Second}
+			attempt, err := webhooks.MakeAttempt(
+				context.Background(), server.Client(), policy,
+				"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, attempt.Status)
+			assert.Equal(t, tc.statusCode, attempt.StatusCode)
+			if tc.wantStatus == webhooks.StatusAttemptToRetry {
+				assert.False(t, attempt.NextRetryAfter.IsZero(), "retryable attempt should schedule a retry")
+			}
+		})
+	}
+}
+
+func TestMakeAttempt_HonorsRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-retry-after",
+		Active: true,
+	}
+
+	// Backoff suggests 15s; Retry-After asks for 120s and must win.
+	policy := &fixedBackoff{delay: 15 * time.Second}
+	before := time.Now().UTC()
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(), policy,
+		"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptToRetry, attempt.Status)
+	assert.GreaterOrEqual(t, attempt.NextRetryAfter.Sub(before), 110*time.Second,
+		"Retry-After (120s) should override the shorter backoff")
+}

--- a/pkg/attempt_test.go
+++ b/pkg/attempt_test.go
@@ -196,6 +196,40 @@ func TestMakeAttempt_HonorsRetryAfter(t *testing.T) {
 		"Retry-After (120s) should override the shorter backoff")
 }
 
+func TestMakeAttempt_RetryAfterIsScheduledFromResponseTime(t *testing.T) {
+	const retryAfter = time.Second
+	const responseDelay = 300 * time.Millisecond
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(responseDelay)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "cfg-retry-after-response-time",
+		Active: true,
+	}
+
+	policy := &fixedBackoff{delay: 100 * time.Millisecond}
+	before := time.Now().UTC()
+	attempt, err := webhooks.MakeAttempt(
+		context.Background(), server.Client(), policy,
+		"attempt-id", "webhook-id", 0, cfg, "", []byte(`{"type":"test.event"}`), false,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, webhooks.StatusAttemptToRetry, attempt.Status)
+	assert.GreaterOrEqual(t, attempt.NextRetryAfter.Sub(before), retryAfter+responseDelay/2,
+		"Retry-After delay must be anchored after the endpoint response, not before the request")
+}
+
 func TestMakeAttempt_RetryAfterCannotExceedAbortAfterWindow(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "21600")

--- a/pkg/backoff.go
+++ b/pkg/backoff.go
@@ -11,3 +11,9 @@ type BackoffPolicy interface {
 type RetryAttemptLimiter interface {
 	CanRetryAttempt(attemptNumber int) error
 }
+
+// RetryDelayLimiter is implemented by retry policies that can reject a custom
+// retry delay before it is persisted.
+type RetryDelayLimiter interface {
+	LimitRetryDelay(attemptNumber int, delay time.Duration) (time.Duration, error)
+}

--- a/pkg/backoff.go
+++ b/pkg/backoff.go
@@ -17,3 +17,9 @@ type RetryAttemptLimiter interface {
 type RetryDelayLimiter interface {
 	LimitRetryDelay(attemptNumber int, delay time.Duration) (time.Duration, error)
 }
+
+// RetryWindowLimiter is implemented by retry policies that can reject a retry
+// schedule based on the real elapsed time since the first delivery attempt.
+type RetryWindowLimiter interface {
+	LimitRetryWindow(elapsed time.Duration) error
+}

--- a/pkg/backoff.go
+++ b/pkg/backoff.go
@@ -5,3 +5,9 @@ import "time"
 type BackoffPolicy interface {
 	GetRetryDelay(attemptNumber int) (time.Duration, error)
 }
+
+// RetryAttemptLimiter is implemented by retry policies that can reject a retry
+// attempt before the outbound HTTP call is made.
+type RetryAttemptLimiter interface {
+	CanRetryAttempt(attemptNumber int) error
+}

--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -56,6 +56,13 @@ func (e *exponential) LimitRetryDelay(attemptNumber int, delay time.Duration) (t
 	return delay, nil
 }
 
+func (e *exponential) LimitRetryWindow(elapsed time.Duration) error {
+	if elapsed > e.abortAfterDelay {
+		return ErrMaxAttemptsReached
+	}
+	return nil
+}
+
 func (e *exponential) retryDelayForAttempt(attemptNumber int) time.Duration {
 	delay := e.minRetryDelay
 	for i := 0; i < attemptNumber; i++ {

--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -35,16 +35,8 @@ func (e *exponential) GetRetryDelay(attemptNumber int) (time.Duration, error) {
 		return 0, ErrMaxAttemptsReached
 	}
 
-	delay := e.minRetryDelay
-	sinceFirstAttempt := delay
-	for i := 0; i < attemptNumber; i++ {
-		delay <<= 1
-		if delay > e.maxRetryDelay {
-			delay = e.maxRetryDelay
-		}
-		sinceFirstAttempt += delay
-	}
-	if sinceFirstAttempt > e.abortAfterDelay {
+	delay := e.retryDelayForAttempt(attemptNumber)
+	if e.elapsedBeforeAttempt(attemptNumber)+delay > e.abortAfterDelay {
 		return 0, ErrMaxAttemptsReached
 	}
 	return delay, nil
@@ -55,4 +47,30 @@ func (e *exponential) CanRetryAttempt(attemptNumber int) error {
 		return ErrMaxAttemptsReached
 	}
 	return nil
+}
+
+func (e *exponential) LimitRetryDelay(attemptNumber int, delay time.Duration) (time.Duration, error) {
+	if e.elapsedBeforeAttempt(attemptNumber)+delay > e.abortAfterDelay {
+		return 0, ErrMaxAttemptsReached
+	}
+	return delay, nil
+}
+
+func (e *exponential) retryDelayForAttempt(attemptNumber int) time.Duration {
+	delay := e.minRetryDelay
+	for i := 0; i < attemptNumber; i++ {
+		delay <<= 1
+		if delay > e.maxRetryDelay {
+			delay = e.maxRetryDelay
+		}
+	}
+	return delay
+}
+
+func (e *exponential) elapsedBeforeAttempt(attemptNumber int) time.Duration {
+	var elapsed time.Duration
+	for i := 0; i < attemptNumber; i++ {
+		elapsed += e.retryDelayForAttempt(i)
+	}
+	return elapsed
 }

--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -31,7 +31,7 @@ type exponential struct {
 }
 
 func (e *exponential) GetRetryDelay(attemptNumber int) (time.Duration, error) {
-	if e.maxAttempts > 0 && attemptNumber >= e.maxAttempts {
+	if e.maxAttempts > 0 && attemptNumber+1 >= e.maxAttempts {
 		return 0, ErrMaxAttemptsReached
 	}
 
@@ -48,4 +48,11 @@ func (e *exponential) GetRetryDelay(attemptNumber int) (time.Duration, error) {
 		return 0, ErrMaxAttemptsReached
 	}
 	return delay, nil
+}
+
+func (e *exponential) CanRetryAttempt(attemptNumber int) error {
+	if e.maxAttempts > 0 && attemptNumber >= e.maxAttempts {
+		return ErrMaxAttemptsReached
+	}
+	return nil
 }

--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -9,11 +9,17 @@ import (
 
 var ErrMaxAttemptsReached = errors.New("max attempts reached")
 
-func NewExponential(minRetryDelay, maxRetryDelay, abortAfterDelay time.Duration) webhooks.BackoffPolicy {
+// NewExponential builds an exponential backoff policy. maxAttempts is a hard cap
+// on the number of attempts: once reached, GetRetryDelay returns
+// ErrMaxAttemptsReached regardless of the abort-after window. A value <= 0
+// disables the cap (abort-after remains the only bound). The cap exists because
+// abort-after alone produced ~724 attempts per dead endpoint in production.
+func NewExponential(minRetryDelay, maxRetryDelay, abortAfterDelay time.Duration, maxAttempts int) webhooks.BackoffPolicy {
 	return &exponential{
 		minRetryDelay,
 		maxRetryDelay,
 		abortAfterDelay,
+		maxAttempts,
 	}
 }
 
@@ -21,9 +27,14 @@ type exponential struct {
 	minRetryDelay   time.Duration
 	maxRetryDelay   time.Duration
 	abortAfterDelay time.Duration
+	maxAttempts     int
 }
 
 func (e *exponential) GetRetryDelay(attemptNumber int) (time.Duration, error) {
+	if e.maxAttempts > 0 && attemptNumber >= e.maxAttempts {
+		return 0, ErrMaxAttemptsReached
+	}
+
 	delay := e.minRetryDelay
 	sinceFirstAttempt := delay
 	for i := 0; i < attemptNumber; i++ {

--- a/pkg/backoff/exponential_test.go
+++ b/pkg/backoff/exponential_test.go
@@ -72,3 +72,18 @@ func TestExponential_CanRetryAttemptOnlyChecksAttemptCap(t *testing.T) {
 	_, err := policy.GetRetryDelay(1)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached, "abort-after still applies when scheduling a future retry")
 }
+
+func TestExponential_LimitRetryDelay(t *testing.T) {
+	policy := NewExponential(time.Minute, time.Hour, 10*time.Minute, 0)
+	limiter, ok := policy.(interface {
+		LimitRetryDelay(int, time.Duration) (time.Duration, error)
+	})
+	assert.True(t, ok)
+
+	delay, err := limiter.LimitRetryDelay(1, 8*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 8*time.Minute, delay)
+
+	_, err = limiter.LimitRetryDelay(1, 10*time.Minute)
+	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
+}

--- a/pkg/backoff/exponential_test.go
+++ b/pkg/backoff/exponential_test.go
@@ -87,3 +87,14 @@ func TestExponential_LimitRetryDelay(t *testing.T) {
 	_, err = limiter.LimitRetryDelay(1, 10*time.Minute)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
 }
+
+func TestExponential_LimitRetryWindow(t *testing.T) {
+	policy := NewExponential(time.Minute, time.Hour, 10*time.Minute, 0)
+	limiter, ok := policy.(interface {
+		LimitRetryWindow(time.Duration) error
+	})
+	assert.True(t, ok)
+
+	assert.NoError(t, limiter.LimitRetryWindow(10*time.Minute))
+	assert.ErrorIs(t, limiter.LimitRetryWindow(10*time.Minute+time.Nanosecond), ErrMaxAttemptsReached)
+}

--- a/pkg/backoff/exponential_test.go
+++ b/pkg/backoff/exponential_test.go
@@ -50,11 +50,25 @@ func TestExponential_MaxAttemptsCap(t *testing.T) {
 	// abort-after is huge, so only the attempt cap (3) can stop retries.
 	policy := NewExponential(time.Minute, time.Hour, 100*24*time.Hour, 3)
 
-	for attempt := range 3 {
+	for attempt := range 2 {
 		_, err := policy.GetRetryDelay(attempt)
-		assert.NoError(t, err, "attempt %d should still be retryable", attempt)
+		assert.NoError(t, err, "attempt %d should be allowed to schedule another retry", attempt)
 	}
 
-	_, err := policy.GetRetryDelay(3)
+	_, err := policy.GetRetryDelay(2)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
+}
+
+func TestExponential_CanRetryAttemptOnlyChecksAttemptCap(t *testing.T) {
+	policy := NewExponential(time.Minute, time.Hour, 2*time.Minute, 3)
+	limiter, ok := policy.(interface {
+		CanRetryAttempt(int) error
+	})
+	assert.True(t, ok)
+
+	assert.NoError(t, limiter.CanRetryAttempt(2))
+	assert.ErrorIs(t, limiter.CanRetryAttempt(3), ErrMaxAttemptsReached)
+
+	_, err := policy.GetRetryDelay(1)
+	assert.ErrorIs(t, err, ErrMaxAttemptsReached, "abort-after still applies when scheduling a future retry")
 }

--- a/pkg/backoff/exponential_test.go
+++ b/pkg/backoff/exponential_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExponential_Nominal(t *testing.T) {
-	policy := NewExponential(time.Minute, time.Hour, 24*time.Hour)
+	policy := NewExponential(time.Minute, time.Hour, 24*time.Hour, 0)
 	wantDurations := []time.Duration{
 		time.Minute,
 		2 * time.Minute,
@@ -36,12 +36,25 @@ func TestExponential_Limit(t *testing.T) {
 	// Attempt:             0    1    2
 	// Delay:               1m   2m   X
 	// sinceFirstAttempt:   1m   3m   X
-	policy := NewExponential(time.Minute, 5*time.Minute, 3*time.Minute)
+	policy := NewExponential(time.Minute, 5*time.Minute, 3*time.Minute, 0)
 
 	delay, err := policy.GetRetryDelay(1)
 	assert.NoError(t, err)
 	assert.Equal(t, 2*time.Minute, delay)
 
 	_, err = policy.GetRetryDelay(2)
+	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
+}
+
+func TestExponential_MaxAttemptsCap(t *testing.T) {
+	// abort-after is huge, so only the attempt cap (3) can stop retries.
+	policy := NewExponential(time.Minute, time.Hour, 100*24*time.Hour, 3)
+
+	for attempt := range 3 {
+		_, err := policy.GetRetryDelay(attempt)
+		assert.NoError(t, err, "attempt %d should still be retryable", attempt)
+	}
+
+	_, err := policy.GetRetryDelay(3)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
 }

--- a/pkg/backoff/noretry.go
+++ b/pkg/backoff/noretry.go
@@ -19,3 +19,7 @@ func (n *NoRetry) GetRetryDelay(attemptNumber int) (time.Duration, error) {
 func (n *NoRetry) CanRetryAttempt(attemptNumber int) error {
 	return ErrMaxAttemptsReached
 }
+
+func (n *NoRetry) LimitRetryDelay(attemptNumber int, delay time.Duration) (time.Duration, error) {
+	return 0, ErrMaxAttemptsReached
+}

--- a/pkg/backoff/noretry.go
+++ b/pkg/backoff/noretry.go
@@ -15,3 +15,7 @@ type NoRetry struct{}
 func (n *NoRetry) GetRetryDelay(attemptNumber int) (time.Duration, error) {
 	return 0, ErrMaxAttemptsReached
 }
+
+func (n *NoRetry) CanRetryAttempt(attemptNumber int) error {
+	return ErrMaxAttemptsReached
+}

--- a/pkg/backoff/noretry_test.go
+++ b/pkg/backoff/noretry_test.go
@@ -10,4 +10,10 @@ func TestNoRetry(t *testing.T) {
 	policy := NewNoRetry()
 	_, err := policy.GetRetryDelay(0)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
+
+	limiter, ok := policy.(interface {
+		CanRetryAttempt(int) error
+	})
+	assert.True(t, ok)
+	assert.ErrorIs(t, limiter.CanRetryAttempt(0), ErrMaxAttemptsReached)
 }

--- a/pkg/backoff/noretry_test.go
+++ b/pkg/backoff/noretry_test.go
@@ -2,6 +2,7 @@ package backoff
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,4 +17,11 @@ func TestNoRetry(t *testing.T) {
 	})
 	assert.True(t, ok)
 	assert.ErrorIs(t, limiter.CanRetryAttempt(0), ErrMaxAttemptsReached)
+
+	delayLimiter, ok := policy.(interface {
+		LimitRetryDelay(int, time.Duration) (time.Duration, error)
+	})
+	assert.True(t, ok)
+	_, err = delayLimiter.LimitRetryDelay(0, time.Second)
+	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
 }

--- a/pkg/backoff/noretry_test.go
+++ b/pkg/backoff/noretry_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNoRetry(t *testing.T) {
@@ -15,13 +16,13 @@ func TestNoRetry(t *testing.T) {
 	limiter, ok := policy.(interface {
 		CanRetryAttempt(int) error
 	})
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.ErrorIs(t, limiter.CanRetryAttempt(0), ErrMaxAttemptsReached)
 
 	delayLimiter, ok := policy.(interface {
 		LimitRetryDelay(int, time.Duration) (time.Duration, error)
 	})
-	assert.True(t, ok)
+	require.True(t, ok)
 	_, err = delayLimiter.LimitRetryDelay(0, time.Second)
 	assert.ErrorIs(t, err, ErrMaxAttemptsReached)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,75 @@
+// Package metrics provides the OpenTelemetry instruments for webhook delivery.
+//
+// Instruments are created lazily from the global meter provider so they bind to
+// the real provider installed by the otlpmetrics fx module at startup (and to a
+// no-op provider, harmlessly, when metrics are disabled — e.g. in unit tests).
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const meterName = "webhooks"
+
+var (
+	once             sync.Once
+	deliveryCounter  metric.Int64Counter
+	deliveryDuration metric.Float64Histogram
+)
+
+func instruments() (metric.Int64Counter, metric.Float64Histogram) {
+	once.Do(func() {
+		meter := otel.GetMeterProvider().Meter(meterName)
+		deliveryCounter, _ = meter.Int64Counter(
+			"webhooks_delivery_attempts_total",
+			metric.WithDescription("Total webhook delivery attempts, by outcome status and HTTP status class"),
+		)
+		deliveryDuration, _ = meter.Float64Histogram(
+			"webhooks_delivery_duration_seconds",
+			metric.WithDescription("Duration of the outbound webhook HTTP call"),
+			metric.WithUnit("s"),
+		)
+	})
+	return deliveryCounter, deliveryDuration
+}
+
+// RecordDelivery records the outcome of a single delivery attempt.
+//
+// Attributes are deliberately low-cardinality (outcome status + HTTP status
+// class). Per-endpoint breakdown is available from the otelhttp delivery spans;
+// we keep it out of metrics to avoid a label-cardinality explosion across the
+// full set of customer endpoints.
+func RecordDelivery(ctx context.Context, status string, statusCode int, elapsed time.Duration) {
+	counter, histogram := instruments()
+	attrs := metric.WithAttributes(
+		attribute.String("status", status),
+		attribute.String("status_class", statusClass(statusCode)),
+	)
+	counter.Add(ctx, 1, attrs)
+	histogram.Record(ctx, elapsed.Seconds(), attrs)
+}
+
+// statusClass buckets an HTTP status code into a low-cardinality class. A code
+// of 0 means the request never got a response (transport/timeout failure).
+func statusClass(statusCode int) string {
+	switch {
+	case statusCode == 0:
+		return "error"
+	case statusCode >= 200 && statusCode < 300:
+		return "2xx"
+	case statusCode >= 300 && statusCode < 400:
+		return "3xx"
+	case statusCode >= 400 && statusCode < 500:
+		return "4xx"
+	case statusCode >= 500:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -124,6 +124,28 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 				return errors.Wrap(err, "dropping redundant partial index for retry polling")
 			},
 		},
+		migrations.Migration{
+			Name: "Add partial indexes for attempts retention",
+			Up: func(ctx context.Context, tx bun.IDB) error {
+				if _, err := tx.ExecContext(ctx, `
+							CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_attempts_retention_success
+							ON attempts (updated_at, id)
+							WHERE status = 'success'
+						`); err != nil {
+					return errors.Wrap(err, "creating partial index for success attempts retention")
+				}
+
+				if _, err := tx.ExecContext(ctx, `
+							CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_attempts_retention_failed
+							ON attempts (updated_at, id)
+							WHERE status = 'failed'
+						`); err != nil {
+					return errors.Wrap(err, "creating partial index for failed attempts retention")
+				}
+
+				return nil
+			},
+		},
 	)
 
 	return migrator.Up(ctx)

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -128,7 +128,13 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 			Name: "Add partial indexes for attempts retention",
 			Up: func(ctx context.Context, tx bun.IDB) error {
 				if _, err := tx.ExecContext(ctx, `
-							CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_attempts_retention_success
+							DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_retention_success
+						`); err != nil {
+					return errors.Wrap(err, "dropping partial index for success attempts retention before rebuild")
+				}
+
+				if _, err := tx.ExecContext(ctx, `
+							CREATE INDEX CONCURRENTLY idx_attempts_retention_success
 							ON attempts (updated_at, id)
 							WHERE status = 'success'
 						`); err != nil {
@@ -136,14 +142,30 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 				}
 
 				if _, err := tx.ExecContext(ctx, `
-							CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_attempts_retention_failed
+							DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_retention_failed
+						`); err != nil {
+					return errors.Wrap(err, "dropping partial index for failed attempts retention before rebuild")
+				}
+
+				if _, err := tx.ExecContext(ctx, `
+							CREATE INDEX CONCURRENTLY idx_attempts_retention_failed
 							ON attempts (updated_at, id)
 							WHERE status = 'failed'
 						`); err != nil {
 					return errors.Wrap(err, "creating partial index for failed attempts retention")
 				}
 
-				return nil
+				if _, err := tx.ExecContext(ctx, `
+							DROP INDEX CONCURRENTLY IF EXISTS idx_attempts_first_attempt_lookup
+						`); err != nil {
+					return errors.Wrap(err, "dropping index for first attempt lookup before rebuild")
+				}
+
+				_, err := tx.ExecContext(ctx, `
+							CREATE INDEX CONCURRENTLY idx_attempts_first_attempt_lookup
+							ON attempts (webhook_id, created_at)
+						`)
+				return errors.Wrap(err, "creating index for first attempt lookup")
 			},
 		},
 	)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -236,8 +236,12 @@ func (s Store) RecoverStaleRetryingAttempts(ctx context.Context, staleDuration t
 }
 
 func (s Store) UpdateAttemptsStatus(ctx context.Context, webhookID, status string) ([]webhooks.Attempt, error) {
+	return updateAttemptsStatus(ctx, s.db, webhookID, status)
+}
+
+func updateAttemptsStatus(ctx context.Context, db bun.IDB, webhookID, status string) ([]webhooks.Attempt, error) {
 	atts := []webhooks.Attempt{}
-	if err := s.db.NewSelect().Model(&atts).
+	if err := db.NewSelect().Model(&atts).
 		Where("webhook_id = ?", webhookID).
 		Where("status = ?", webhooks.StatusAttemptRetrying).
 		Scan(ctx); err != nil {
@@ -251,7 +255,7 @@ func (s Store) UpdateAttemptsStatus(ctx context.Context, webhookID, status strin
 		return []webhooks.Attempt{}, storage.ErrAttemptsNotModified
 	}
 
-	if _, err := s.db.NewUpdate().Model((*webhooks.Attempt)(nil)).
+	if _, err := db.NewUpdate().Model((*webhooks.Attempt)(nil)).
 		Where("webhook_id = ?", webhookID).
 		Where("status = ?", webhooks.StatusAttemptRetrying).
 		Set("status = ?", status).
@@ -270,6 +274,26 @@ func (s Store) UpdateAttemptsStatus(ctx context.Context, webhookID, status strin
 func (s Store) InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error {
 	if _, err := s.db.NewInsert().Model(&att).Exec(ctx); err != nil {
 		return errors.Wrap(err, "inserting one attempt")
+	}
+
+	return nil
+}
+
+func (s Store) InsertOneAttemptAndUpdateAttemptsStatus(ctx context.Context, att webhooks.Attempt, webhookID string, status string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "beginning attempt transaction")
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.NewInsert().Model(&att).Exec(ctx); err != nil {
+		return errors.Wrap(err, "inserting one attempt")
+	}
+	if _, err := updateAttemptsStatus(ctx, tx, webhookID, status); err != nil {
+		return errors.Wrap(err, "updating attempts status")
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "committing attempt transaction")
 	}
 
 	return nil
@@ -296,88 +320,88 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 		}
 		cutoff := time.Now().UTC().Add(-t.retention)
 
-		// Delete in bounded batches so a large backlog does not lock the table or
-		// generate one huge transaction. SKIP LOCKED keeps concurrent retention
-		// runners (multiple worker replicas) from contending on the same rows.
-		// Loop until a batch deletes fewer rows than requested (backlog drained).
-		for {
-			res, err := s.db.NewRaw(`
-				DELETE FROM attempts
-				WHERE id IN (
-					SELECT id FROM attempts
-					WHERE status = ? AND updated_at < ?
-					LIMIT ?
-					FOR UPDATE SKIP LOCKED
-				)
-			`, t.status, cutoff, batchSize).Exec(ctx)
-			if err != nil {
-				return total, errors.Wrapf(err, "purging %q attempts", t.status)
-			}
-			affected, err := res.RowsAffected()
-			if err != nil {
-				return total, errors.Wrap(err, "reading purge rows affected")
-			}
-			total += affected
-			if affected < int64(batchSize) {
-				break
-			}
+		// Delete at most one bounded batch per status and run so first deploys
+		// against a large backlog do not monopolize the attempts table.
+		res, err := s.db.NewRaw(`
+			DELETE FROM attempts
+			WHERE id IN (
+				SELECT id FROM attempts
+				WHERE status = ? AND updated_at < ?
+				LIMIT ?
+				FOR UPDATE SKIP LOCKED
+			)
+		`, t.status, cutoff, batchSize).Exec(ctx)
+		if err != nil {
+			return total, errors.Wrapf(err, "purging %q attempts", t.status)
 		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return total, errors.Wrap(err, "reading purge rows affected")
+		}
+		total += affected
 	}
 
 	return total, nil
 }
 
-func (s Store) FailUnclaimableAttempts(ctx context.Context, batchSize int) (int64, error) {
+func (s Store) FailUnclaimableAttempts(ctx context.Context, batchSize int, retryingStaleDuration time.Duration) (int64, error) {
 	if batchSize <= 0 {
 		batchSize = 1000
 	}
-
-	// Update in bounded batches: the production backlog of unclaimable attempts
-	// reached millions of rows, and a single UPDATE over all of them would hold
-	// locks and generate one giant transaction. SKIP LOCKED keeps concurrent
-	// retention runners from contending on the same rows.
-	var total int64
-	for {
-		res, err := s.db.NewRaw(`
-			UPDATE attempts
-			SET status = ?, updated_at = NOW()
-			WHERE id IN (
-				SELECT id FROM attempts
-				WHERE status IN (?, ?)
-				  AND NOT EXISTS (
-					SELECT 1
-					FROM configs c
-					WHERE c.id = attempts.config->>'id'
-					  AND c.active = true
-				  )
-				LIMIT ?
-				FOR UPDATE SKIP LOCKED
-			)
-		`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry,
-			webhooks.StatusAttemptRetrying, batchSize).Exec(ctx)
-		if err != nil {
-			return total, errors.Wrap(err, "failing unclaimable attempts")
-		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return total, errors.Wrap(err, "reading unclaimable rows affected")
-		}
-		total += affected
-		if affected < int64(batchSize) {
-			return total, nil
-		}
+	if retryingStaleDuration <= 0 {
+		retryingStaleDuration = 5 * time.Minute
 	}
+	staleCutoff := time.Now().UTC().Add(-retryingStaleDuration)
+
+	// Update at most one bounded batch per run. Retry rows that are actively
+	// claimed stay untouched unless they are stale, matching retry recovery.
+	res, err := s.db.NewRaw(`
+		UPDATE attempts
+		SET status = ?, updated_at = NOW()
+		WHERE id IN (
+			SELECT id FROM attempts
+			WHERE (
+				status = ?
+				OR (status = ? AND updated_at < ?)
+			)
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM configs c
+				WHERE c.id = attempts.config->>'id'
+				  AND c.active = true
+			  )
+			LIMIT ?
+			FOR UPDATE SKIP LOCKED
+		)
+	`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry,
+		webhooks.StatusAttemptRetrying, staleCutoff, batchSize).Exec(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "failing unclaimable attempts")
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, errors.Wrap(err, "reading unclaimable rows affected")
+	}
+
+	return affected, nil
 }
 
+const retryQueueDepthCountLimit = 1_000_000
+
 func (s Store) CountAttemptsToRetry(ctx context.Context) (int64, error) {
-	count, err := s.db.NewSelect().
-		Model((*webhooks.Attempt)(nil)).
-		Where("status = ?", webhooks.StatusAttemptToRetry).
-		Count(ctx)
-	if err != nil {
+	var count int64
+	if err := s.db.NewRaw(`
+		SELECT count(*)
+		FROM (
+			SELECT 1
+			FROM attempts
+			WHERE status = ?
+			LIMIT ?
+		) bounded_attempts
+	`, webhooks.StatusAttemptToRetry, retryQueueDepthCountLimit).Scan(ctx, &count); err != nil {
 		return 0, errors.Wrap(err, "counting attempts to retry")
 	}
-	return int64(count), nil
+	return count, nil
 }
 
 func (s Store) Close(ctx context.Context) error {

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -280,8 +280,9 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 		cutoff := time.Now().UTC().Add(-t.retention)
 
 		// Delete in bounded batches so a large backlog does not lock the table or
-		// generate one huge transaction. Loop until a batch deletes fewer rows
-		// than requested, meaning the backlog is drained.
+		// generate one huge transaction. SKIP LOCKED keeps concurrent retention
+		// runners (multiple worker replicas) from contending on the same rows.
+		// Loop until a batch deletes fewer rows than requested (backlog drained).
 		for {
 			res, err := s.db.NewRaw(`
 				DELETE FROM attempts
@@ -289,6 +290,7 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 					SELECT id FROM attempts
 					WHERE status = ? AND updated_at < ?
 					LIMIT ?
+					FOR UPDATE SKIP LOCKED
 				)
 			`, t.status, cutoff, batchSize).Exec(ctx)
 			if err != nil {
@@ -308,23 +310,43 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 	return total, nil
 }
 
-func (s Store) FailOrphanedAttempts(ctx context.Context) (int64, error) {
-	res, err := s.db.NewRaw(`
-		UPDATE attempts
-		SET status = ?, updated_at = NOW()
-		WHERE status IN (?, ?)
-		  AND NOT EXISTS (
-			SELECT 1 FROM configs c WHERE c.id = attempts.config->>'id'
-		  )
-	`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry, webhooks.StatusAttemptRetrying).Exec(ctx)
-	if err != nil {
-		return 0, errors.Wrap(err, "failing orphaned attempts")
+func (s Store) FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 1000
 	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return 0, errors.Wrap(err, "reading orphaned rows affected")
+
+	// Update in bounded batches: the production backlog of orphaned attempts
+	// reached millions of rows, and a single UPDATE over all of them would hold
+	// locks and generate one giant transaction. SKIP LOCKED keeps concurrent
+	// retention runners from contending on the same rows.
+	var total int64
+	for {
+		res, err := s.db.NewRaw(`
+			UPDATE attempts
+			SET status = ?, updated_at = NOW()
+			WHERE id IN (
+				SELECT id FROM attempts
+				WHERE status IN (?, ?)
+				  AND NOT EXISTS (
+					SELECT 1 FROM configs c WHERE c.id = attempts.config->>'id'
+				  )
+				LIMIT ?
+				FOR UPDATE SKIP LOCKED
+			)
+		`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry,
+			webhooks.StatusAttemptRetrying, batchSize).Exec(ctx)
+		if err != nil {
+			return total, errors.Wrap(err, "failing orphaned attempts")
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return total, errors.Wrap(err, "reading orphaned rows affected")
+		}
+		total += affected
+		if affected < int64(batchSize) {
+			return total, nil
+		}
 	}
-	return affected, nil
 }
 
 func (s Store) CountAttemptsToRetry(ctx context.Context) (int64, error) {

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -325,12 +325,22 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 		res, err := s.db.NewRaw(`
 			DELETE FROM attempts
 			WHERE id IN (
-				SELECT id FROM attempts
-				WHERE status = ? AND updated_at < ?
+				SELECT candidate.id FROM attempts candidate
+				WHERE candidate.status = ? AND candidate.updated_at < ?
+				  AND (
+					? != ?
+					OR NOT EXISTS (
+						SELECT 1
+						FROM attempts pending
+						WHERE pending.webhook_id = candidate.webhook_id
+						  AND pending.status IN (?, ?)
+					)
+				  )
 				LIMIT ?
 				FOR UPDATE SKIP LOCKED
 			)
-		`, t.status, cutoff, batchSize).Exec(ctx)
+		`, t.status, cutoff, t.status, webhooks.StatusAttemptFailed,
+			webhooks.StatusAttemptToRetry, webhooks.StatusAttemptRetrying, batchSize).Exec(ctx)
 		if err != nil {
 			return total, errors.Wrapf(err, "purging %q attempts", t.status)
 		}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -153,6 +153,23 @@ func (s Store) FindAttemptsToRetryByWebhookID(ctx context.Context, webhookID str
 	return res, nil
 }
 
+func (s Store) FindFirstAttemptCreatedAtByWebhookID(ctx context.Context, webhookID string) (time.Time, error) {
+	var att webhooks.Attempt
+	if err := s.db.NewSelect().Model(&att).
+		Column("created_at").
+		Where("webhook_id = ?", webhookID).
+		Order("created_at ASC").
+		Limit(1).
+		Scan(ctx); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, storage.ErrWebhookIDNotFound
+		}
+		return time.Time{}, errors.Wrap(err, "finding first attempt created_at")
+	}
+
+	return att.CreatedAt, nil
+}
+
 func (s Store) FindWebhookIDsToRetry(ctx context.Context, limit int) ([]string, error) {
 	// Raw SQL is required here: the atomic claim pattern (SELECT + UPDATE in a single
 	// statement via CTE) cannot be expressed with Bun's query builder.

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -258,6 +258,75 @@ func (s Store) InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error
 	return nil
 }
 
+func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, failedOlderThan time.Duration, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+
+	type purgeTarget struct {
+		status    string
+		retention time.Duration
+	}
+	targets := []purgeTarget{
+		{webhooks.StatusAttemptSuccess, successOlderThan},
+		{webhooks.StatusAttemptFailed, failedOlderThan},
+	}
+
+	var total int64
+	for _, t := range targets {
+		if t.retention <= 0 {
+			continue
+		}
+		cutoff := time.Now().UTC().Add(-t.retention)
+
+		// Delete in bounded batches so a large backlog does not lock the table or
+		// generate one huge transaction. Loop until a batch deletes fewer rows
+		// than requested, meaning the backlog is drained.
+		for {
+			res, err := s.db.NewRaw(`
+				DELETE FROM attempts
+				WHERE id IN (
+					SELECT id FROM attempts
+					WHERE status = ? AND updated_at < ?
+					LIMIT ?
+				)
+			`, t.status, cutoff, batchSize).Exec(ctx)
+			if err != nil {
+				return total, errors.Wrapf(err, "purging %q attempts", t.status)
+			}
+			affected, err := res.RowsAffected()
+			if err != nil {
+				return total, errors.Wrap(err, "reading purge rows affected")
+			}
+			total += affected
+			if affected < int64(batchSize) {
+				break
+			}
+		}
+	}
+
+	return total, nil
+}
+
+func (s Store) FailOrphanedAttempts(ctx context.Context) (int64, error) {
+	res, err := s.db.NewRaw(`
+		UPDATE attempts
+		SET status = ?, updated_at = NOW()
+		WHERE status IN (?, ?)
+		  AND NOT EXISTS (
+			SELECT 1 FROM configs c WHERE c.id = attempts.config->>'id'
+		  )
+	`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry, webhooks.StatusAttemptRetrying).Exec(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "failing orphaned attempts")
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, errors.Wrap(err, "reading orphaned rows affected")
+	}
+	return affected, nil
+}
+
 func (s Store) Close(ctx context.Context) error {
 	return s.db.Close()
 }

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -327,6 +327,17 @@ func (s Store) FailOrphanedAttempts(ctx context.Context) (int64, error) {
 	return affected, nil
 }
 
+func (s Store) CountAttemptsToRetry(ctx context.Context) (int64, error) {
+	count, err := s.db.NewSelect().
+		Model((*webhooks.Attempt)(nil)).
+		Where("status = ?", webhooks.StatusAttemptToRetry).
+		Count(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "counting attempts to retry")
+	}
+	return int64(count), nil
+}
+
 func (s Store) Close(ctx context.Context) error {
 	return s.db.Close()
 }

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -310,12 +310,12 @@ func (s Store) PurgeFinishedAttempts(ctx context.Context, successOlderThan, fail
 	return total, nil
 }
 
-func (s Store) FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, error) {
+func (s Store) FailUnclaimableAttempts(ctx context.Context, batchSize int) (int64, error) {
 	if batchSize <= 0 {
 		batchSize = 1000
 	}
 
-	// Update in bounded batches: the production backlog of orphaned attempts
+	// Update in bounded batches: the production backlog of unclaimable attempts
 	// reached millions of rows, and a single UPDATE over all of them would hold
 	// locks and generate one giant transaction. SKIP LOCKED keeps concurrent
 	// retention runners from contending on the same rows.
@@ -328,7 +328,10 @@ func (s Store) FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, 
 				SELECT id FROM attempts
 				WHERE status IN (?, ?)
 				  AND NOT EXISTS (
-					SELECT 1 FROM configs c WHERE c.id = attempts.config->>'id'
+					SELECT 1
+					FROM configs c
+					WHERE c.id = attempts.config->>'id'
+					  AND c.active = true
 				  )
 				LIMIT ?
 				FOR UPDATE SKIP LOCKED
@@ -336,11 +339,11 @@ func (s Store) FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, 
 		`, webhooks.StatusAttemptFailed, webhooks.StatusAttemptToRetry,
 			webhooks.StatusAttemptRetrying, batchSize).Exec(ctx)
 		if err != nil {
-			return total, errors.Wrap(err, "failing orphaned attempts")
+			return total, errors.Wrap(err, "failing unclaimable attempts")
 		}
 		affected, err := res.RowsAffected()
 		if err != nil {
-			return total, errors.Wrap(err, "reading orphaned rows affected")
+			return total, errors.Wrap(err, "reading unclaimable rows affected")
 		}
 		total += affected
 		if affected < int64(batchSize) {

--- a/pkg/storage/postgres/retention_test.go
+++ b/pkg/storage/postgres/retention_test.go
@@ -154,7 +154,36 @@ func TestPurgeFinishedAttemptsBatches(t *testing.T) {
 	require.EqualValues(t, 5, deleted)
 }
 
-func TestFailOrphanedAttempts(t *testing.T) {
+func TestRetentionIndexesExist(t *testing.T) {
+	_, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{"idx_attempts_retention_success", "success"},
+		{"idx_attempts_retention_failed", "failed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var indexDef string
+			err := db.NewRaw(`
+				SELECT indexdef
+				FROM pg_indexes
+				WHERE tablename = 'attempts' AND indexname = ?
+			`, tc.name).Scan(ctx, &indexDef)
+			require.NoError(t, err)
+			require.Contains(t, indexDef, "updated_at")
+			require.Contains(t, indexDef, "id")
+			require.Contains(t, indexDef, "WHERE")
+			require.Contains(t, indexDef, tc.status)
+		})
+	}
+}
+
+func TestFailUnclaimableAttempts(t *testing.T) {
 	store, db := newTestStoreWithDB(t)
 	ctx := context.Background()
 
@@ -163,6 +192,15 @@ func TestFailOrphanedAttempts(t *testing.T) {
 	// Live config: its pending attempts must be preserved.
 	liveCfg := insertConfig(t, store)
 	liveToRetry := insertAttemptAged(t, store, liveCfg, webhooks.StatusAttemptToRetry, now)
+
+	// Inactive config: retry claim skips it, so its pending attempts must be
+	// failed by retention instead of staying in the retry queue forever.
+	inactiveCfg := insertConfig(t, store)
+	_, err := store.UpdateOneConfigActivation(ctx, inactiveCfg.ID, false)
+	require.NoError(t, err)
+	inactiveToRetry := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptToRetry, now)
+	inactiveRetrying := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptRetrying, now)
+	inactiveSuccess := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptSuccess, now)
 
 	// Orphan config: never persisted, simulating a deleted config snapshotted
 	// in the attempt's JSONB column.
@@ -175,12 +213,15 @@ func TestFailOrphanedAttempts(t *testing.T) {
 	orphanRetrying := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptRetrying, now)
 	orphanSuccess := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptSuccess, now)
 
-	updated, err := store.FailOrphanedAttempts(ctx, 1) // batchSize 1 to exercise the loop
+	updated, err := store.FailUnclaimableAttempts(ctx, 1) // batchSize 1 to exercise the loop
 	require.NoError(t, err)
-	require.EqualValues(t, 2, updated, "only pending orphan attempts should be failed")
+	require.EqualValues(t, 4, updated, "only pending inactive/deleted config attempts should be failed")
 
 	statuses := attemptStatusesByID(t, db)
 	require.Equal(t, webhooks.StatusAttemptToRetry, statuses[liveToRetry], "live config attempts must be preserved")
+	require.Equal(t, webhooks.StatusAttemptFailed, statuses[inactiveToRetry])
+	require.Equal(t, webhooks.StatusAttemptFailed, statuses[inactiveRetrying])
+	require.Equal(t, webhooks.StatusAttemptSuccess, statuses[inactiveSuccess], "terminal inactive-config attempts must not be rewritten")
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanToRetry])
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanRetrying])
 	require.Equal(t, webhooks.StatusAttemptSuccess, statuses[orphanSuccess], "terminal orphan attempts must not be rewritten")

--- a/pkg/storage/postgres/retention_test.go
+++ b/pkg/storage/postgres/retention_test.go
@@ -138,6 +138,52 @@ func TestPurgeFinishedAttemptsDisabledRetention(t *testing.T) {
 	require.NotContains(t, remaining, oldFailed)
 }
 
+func TestPurgeFinishedAttemptsPreservesFailedHistoryForActiveRetry(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+	cfg := insertConfig(t, store)
+
+	webhookID := uuid.NewString()
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	nextRetry := time.Now().UTC().Add(time.Hour)
+	oldFailed := webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    webhookID,
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   500,
+		RetryAttempt: 1,
+		Status:       webhooks.StatusAttemptFailed,
+		CreatedAt:    old,
+		UpdatedAt:    old,
+	}
+	pending := webhooks.Attempt{
+		ID:             uuid.NewString(),
+		WebhookID:      webhookID,
+		Config:         cfg,
+		Payload:        string(payload),
+		StatusCode:     500,
+		RetryAttempt:   2,
+		Status:         webhooks.StatusAttemptToRetry,
+		NextRetryAfter: nextRetry,
+		CreatedAt:      nextRetry,
+		UpdatedAt:      nextRetry,
+	}
+	standaloneFailed := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptFailed, old)
+	require.NoError(t, store.InsertOneAttempt(ctx, oldFailed))
+	require.NoError(t, store.InsertOneAttempt(ctx, pending))
+
+	deleted, err := store.PurgeFinishedAttempts(ctx, 0, 24*time.Hour, 100)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted, "only terminal failed attempts without active retry siblings should be purged")
+
+	remaining := remainingAttemptIDs(t, db)
+	require.Contains(t, remaining, oldFailed.ID, "failed history is needed to keep abort-after anchored")
+	require.Contains(t, remaining, pending.ID)
+	require.NotContains(t, remaining, standaloneFailed)
+}
+
 func TestPurgeFinishedAttemptsBatches(t *testing.T) {
 	store, _ := newTestStoreWithDB(t)
 	ctx := context.Background()

--- a/pkg/storage/postgres/retention_test.go
+++ b/pkg/storage/postgres/retention_test.go
@@ -148,10 +148,18 @@ func TestPurgeFinishedAttemptsBatches(t *testing.T) {
 		insertAttemptAged(t, store, cfg, webhooks.StatusAttemptSuccess, old)
 	}
 
-	// batchSize smaller than the backlog: the loop must drain everything
+	// batchSize smaller than the backlog: each run consumes only one batch.
 	deleted, err := store.PurgeFinishedAttempts(ctx, 24*time.Hour, 24*time.Hour, 2)
 	require.NoError(t, err)
-	require.EqualValues(t, 5, deleted)
+	require.EqualValues(t, 2, deleted)
+
+	deleted, err = store.PurgeFinishedAttempts(ctx, 24*time.Hour, 24*time.Hour, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, deleted)
+
+	deleted, err = store.PurgeFinishedAttempts(ctx, 24*time.Hour, 24*time.Hour, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
 }
 
 func TestRetentionIndexesExist(t *testing.T) {
@@ -181,6 +189,18 @@ func TestRetentionIndexesExist(t *testing.T) {
 			require.Contains(t, indexDef, tc.status)
 		})
 	}
+
+	t.Run("idx_attempts_first_attempt_lookup", func(t *testing.T) {
+		var indexDef string
+		err := db.NewRaw(`
+			SELECT indexdef
+			FROM pg_indexes
+			WHERE tablename = 'attempts' AND indexname = ?
+		`, "idx_attempts_first_attempt_lookup").Scan(ctx, &indexDef)
+		require.NoError(t, err)
+		require.Contains(t, indexDef, "webhook_id")
+		require.Contains(t, indexDef, "created_at")
+	})
 }
 
 func TestFailUnclaimableAttempts(t *testing.T) {
@@ -188,6 +208,7 @@ func TestFailUnclaimableAttempts(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now().UTC()
+	stale := now.Add(-10 * time.Minute)
 
 	// Live config: its pending attempts must be preserved.
 	liveCfg := insertConfig(t, store)
@@ -199,7 +220,8 @@ func TestFailUnclaimableAttempts(t *testing.T) {
 	_, err := store.UpdateOneConfigActivation(ctx, inactiveCfg.ID, false)
 	require.NoError(t, err)
 	inactiveToRetry := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptToRetry, now)
-	inactiveRetrying := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptRetrying, now)
+	inactiveRetrying := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptRetrying, stale)
+	inactiveRetryingRecent := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptRetrying, now)
 	inactiveSuccess := insertAttemptAged(t, store, inactiveCfg, webhooks.StatusAttemptSuccess, now)
 
 	// Orphan config: never persisted, simulating a deleted config snapshotted
@@ -210,20 +232,23 @@ func TestFailUnclaimableAttempts(t *testing.T) {
 		EventTypes: []string{"test.event"},
 	})
 	orphanToRetry := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptToRetry, now)
-	orphanRetrying := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptRetrying, now)
+	orphanRetrying := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptRetrying, stale)
+	orphanRetryingRecent := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptRetrying, now)
 	orphanSuccess := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptSuccess, now)
 
-	updated, err := store.FailUnclaimableAttempts(ctx, 1) // batchSize 1 to exercise the loop
+	updated, err := store.FailUnclaimableAttempts(ctx, 100, 5*time.Minute)
 	require.NoError(t, err)
-	require.EqualValues(t, 4, updated, "only pending inactive/deleted config attempts should be failed")
+	require.EqualValues(t, 4, updated, "only pending to-retry and stale retrying inactive/deleted config attempts should be failed")
 
 	statuses := attemptStatusesByID(t, db)
 	require.Equal(t, webhooks.StatusAttemptToRetry, statuses[liveToRetry], "live config attempts must be preserved")
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[inactiveToRetry])
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[inactiveRetrying])
+	require.Equal(t, webhooks.StatusAttemptRetrying, statuses[inactiveRetryingRecent], "recent retrying rows may still be in-flight")
 	require.Equal(t, webhooks.StatusAttemptSuccess, statuses[inactiveSuccess], "terminal inactive-config attempts must not be rewritten")
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanToRetry])
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanRetrying])
+	require.Equal(t, webhooks.StatusAttemptRetrying, statuses[orphanRetryingRecent], "recent retrying rows may still be in-flight")
 	require.Equal(t, webhooks.StatusAttemptSuccess, statuses[orphanSuccess], "terminal orphan attempts must not be rewritten")
 
 	require.Equal(t, 1, countAttemptsByStatus(t, store, webhooks.StatusAttemptToRetry))

--- a/pkg/storage/postgres/retention_test.go
+++ b/pkg/storage/postgres/retention_test.go
@@ -1,0 +1,189 @@
+package postgres_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+
+	webhooks "github.com/formancehq/webhooks/pkg"
+	"github.com/formancehq/webhooks/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// remainingAttemptIDs returns the set of attempt IDs still present in the table.
+func remainingAttemptIDs(t *testing.T, db *bun.DB) map[string]struct{} {
+	t.Helper()
+
+	atts := []webhooks.Attempt{}
+	require.NoError(t, db.NewSelect().Model(&atts).Scan(context.Background()))
+	ids := make(map[string]struct{}, len(atts))
+	for _, att := range atts {
+		ids[att.ID] = struct{}{}
+	}
+	return ids
+}
+
+// attemptStatusesByID returns attempt ID -> status for all rows.
+func attemptStatusesByID(t *testing.T, db *bun.DB) map[string]string {
+	t.Helper()
+
+	atts := []webhooks.Attempt{}
+	require.NoError(t, db.NewSelect().Model(&atts).Scan(context.Background()))
+	statuses := make(map[string]string, len(atts))
+	for _, att := range atts {
+		statuses[att.ID] = att.Status
+	}
+	return statuses
+}
+
+// insertAttemptAged inserts an attempt with an explicit updated_at so retention
+// cutoffs can be exercised deterministically.
+func insertAttemptAged(t *testing.T, store storage.Store, cfg webhooks.Config, status string, updatedAt time.Time) string {
+	t.Helper()
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+	att := webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    uuid.NewString(),
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   500,
+		RetryAttempt: 1,
+		Status:       status,
+		UpdatedAt:    updatedAt,
+	}
+	if status == webhooks.StatusAttemptToRetry {
+		att.NextRetryAfter = time.Now().UTC().Add(time.Minute)
+	}
+	require.NoError(t, store.InsertOneAttempt(context.Background(), att))
+	return att.ID
+}
+
+func insertConfig(t *testing.T, store storage.Store) webhooks.Config {
+	t.Helper()
+
+	cfg, err := store.InsertOneConfig(context.Background(), webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+	return cfg
+}
+
+func countAttemptsByStatus(t *testing.T, store storage.Store, status string) int {
+	t.Helper()
+
+	// Reuse the storage API instead of raw SQL: FindAttemptsToRetryByWebhookID
+	// is webhook-scoped, so go through CountAttemptsToRetry for 'to retry' and
+	// a generic count via UpdateAttemptsStatus is not suitable — use the bun DB
+	// from the store-level helper instead.
+	switch status {
+	case webhooks.StatusAttemptToRetry:
+		n, err := store.CountAttemptsToRetry(context.Background())
+		require.NoError(t, err)
+		return int(n)
+	default:
+		t.Fatalf("unsupported status for countAttemptsByStatus: %s", status)
+		return 0
+	}
+}
+
+func TestPurgeFinishedAttempts(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+	cfg := insertConfig(t, store)
+
+	now := time.Now().UTC()
+	old := now.Add(-72 * time.Hour)
+
+	oldSuccess := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptSuccess, old)
+	recentSuccess := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptSuccess, now)
+	oldFailed := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptFailed, old)
+	recentFailed := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptFailed, now)
+	oldToRetry := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptToRetry, old)
+
+	deleted, err := store.PurgeFinishedAttempts(ctx, 24*time.Hour, 24*time.Hour, 100)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, deleted, "only the old success and old failed attempts should be purged")
+
+	remaining := remainingAttemptIDs(t, db)
+	require.NotContains(t, remaining, oldSuccess)
+	require.NotContains(t, remaining, oldFailed)
+	require.Contains(t, remaining, recentSuccess)
+	require.Contains(t, remaining, recentFailed)
+	require.Contains(t, remaining, oldToRetry, "pending attempts must never be purged regardless of age")
+}
+
+func TestPurgeFinishedAttemptsDisabledRetention(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+	cfg := insertConfig(t, store)
+
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	oldSuccess := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptSuccess, old)
+	oldFailed := insertAttemptAged(t, store, cfg, webhooks.StatusAttemptFailed, old)
+
+	// success retention disabled, failed retention active
+	deleted, err := store.PurgeFinishedAttempts(ctx, 0, 24*time.Hour, 100)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
+
+	remaining := remainingAttemptIDs(t, db)
+	require.Contains(t, remaining, oldSuccess, "a retention <= 0 must disable purging for that status")
+	require.NotContains(t, remaining, oldFailed)
+}
+
+func TestPurgeFinishedAttemptsBatches(t *testing.T) {
+	store, _ := newTestStoreWithDB(t)
+	ctx := context.Background()
+	cfg := insertConfig(t, store)
+
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	for range 5 {
+		insertAttemptAged(t, store, cfg, webhooks.StatusAttemptSuccess, old)
+	}
+
+	// batchSize smaller than the backlog: the loop must drain everything
+	deleted, err := store.PurgeFinishedAttempts(ctx, 24*time.Hour, 24*time.Hour, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, deleted)
+}
+
+func TestFailOrphanedAttempts(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	// Live config: its pending attempts must be preserved.
+	liveCfg := insertConfig(t, store)
+	liveToRetry := insertAttemptAged(t, store, liveCfg, webhooks.StatusAttemptToRetry, now)
+
+	// Orphan config: never persisted, simulating a deleted config snapshotted
+	// in the attempt's JSONB column.
+	orphanCfg := webhooks.NewConfig(webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	orphanToRetry := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptToRetry, now)
+	orphanRetrying := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptRetrying, now)
+	orphanSuccess := insertAttemptAged(t, store, orphanCfg, webhooks.StatusAttemptSuccess, now)
+
+	updated, err := store.FailOrphanedAttempts(ctx, 1) // batchSize 1 to exercise the loop
+	require.NoError(t, err)
+	require.EqualValues(t, 2, updated, "only pending orphan attempts should be failed")
+
+	statuses := attemptStatusesByID(t, db)
+	require.Equal(t, webhooks.StatusAttemptToRetry, statuses[liveToRetry], "live config attempts must be preserved")
+	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanToRetry])
+	require.Equal(t, webhooks.StatusAttemptFailed, statuses[orphanRetrying])
+	require.Equal(t, webhooks.StatusAttemptSuccess, statuses[orphanSuccess], "terminal orphan attempts must not be rewritten")
+
+	require.Equal(t, 1, countAttemptsByStatus(t, store, webhooks.StatusAttemptToRetry))
+}

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -348,6 +348,56 @@ func TestUpdateAttemptsStatusOnlyUpdatesRetrying(t *testing.T) {
 	require.Len(t, atts, 0)
 }
 
+func TestInsertOneAttemptAndUpdateAttemptsStatusIsAtomicStateTransition(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+	claimed := webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    webhookID,
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   500,
+		RetryAttempt: 1,
+		Status:       webhooks.StatusAttemptRetrying,
+	}
+	next := webhooks.Attempt{
+		ID:             uuid.NewString(),
+		WebhookID:      webhookID,
+		Config:         cfg,
+		Payload:        string(payload),
+		StatusCode:     500,
+		RetryAttempt:   2,
+		Status:         webhooks.StatusAttemptToRetry,
+		NextRetryAfter: time.Now().UTC().Add(time.Minute),
+	}
+
+	require.NoError(t, store.InsertOneAttempt(ctx, claimed))
+	require.NoError(t, store.InsertOneAttemptAndUpdateAttemptsStatus(ctx, next, webhookID, webhooks.StatusAttemptFailed))
+
+	atts := []webhooks.Attempt{}
+	require.NoError(t, db.NewSelect().Model(&atts).
+		Where("id IN (?)", bun.List([]string{claimed.ID, next.ID})).
+		Scan(ctx))
+	require.Len(t, atts, 2)
+
+	statuses := make(map[string]string, len(atts))
+	for _, att := range atts {
+		statuses[att.ID] = att.Status
+	}
+	require.Equal(t, webhooks.StatusAttemptFailed, statuses[claimed.ID])
+	require.Equal(t, webhooks.StatusAttemptToRetry, statuses[next.ID])
+}
+
 func TestRecoverStaleRetryingAttempts(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -86,6 +86,50 @@ func insertAttemptWithConfig(t *testing.T, db storage.Store, webhookID string, c
 	require.NoError(t, db.InsertOneAttempt(ctx, att))
 }
 
+func TestFindFirstAttemptCreatedAtByWebhookID(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	webhookID := uuid.NewString()
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	first := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Microsecond)
+	second := first.Add(time.Hour)
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	require.NoError(t, store.InsertOneAttempt(ctx, webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    webhookID,
+		CreatedAt:    second,
+		UpdatedAt:    second,
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   500,
+		RetryAttempt: 1,
+		Status:       webhooks.StatusAttemptToRetry,
+	}))
+	require.NoError(t, store.InsertOneAttempt(ctx, webhooks.Attempt{
+		ID:           uuid.NewString(),
+		WebhookID:    webhookID,
+		CreatedAt:    first,
+		UpdatedAt:    first,
+		Config:       cfg,
+		Payload:      string(payload),
+		StatusCode:   500,
+		RetryAttempt: 0,
+		Status:       webhooks.StatusAttemptFailed,
+	}))
+
+	got, err := store.FindFirstAttemptCreatedAtByWebhookID(ctx, webhookID)
+	require.NoError(t, err)
+	require.Equal(t, first, got.UTC())
+}
+
 func TestClaimWebhookIDsToRetry(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/storage/postgres/retry_test.go
+++ b/pkg/storage/postgres/retry_test.go
@@ -130,6 +130,14 @@ func TestFindFirstAttemptCreatedAtByWebhookID(t *testing.T) {
 	require.Equal(t, first, got.UTC())
 }
 
+func TestFindFirstAttemptCreatedAtByWebhookIDNotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.FindFirstAttemptCreatedAtByWebhookID(ctx, uuid.NewString())
+	require.ErrorIs(t, err, storage.ErrWebhookIDNotFound)
+}
+
 func TestClaimWebhookIDsToRetry(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
@@ -396,6 +404,39 @@ func TestInsertOneAttemptAndUpdateAttemptsStatusIsAtomicStateTransition(t *testi
 	}
 	require.Equal(t, webhooks.StatusAttemptFailed, statuses[claimed.ID])
 	require.Equal(t, webhooks.StatusAttemptToRetry, statuses[next.ID])
+}
+
+func TestInsertOneAttemptAndUpdateAttemptsStatusRollsBackWhenUpdateFails(t *testing.T) {
+	store, db := newTestStoreWithDB(t)
+	ctx := context.Background()
+
+	cfg, err := store.InsertOneConfig(ctx, webhooks.ConfigUser{
+		Endpoint:   "http://localhost:8080",
+		Secret:     webhooks.NewSecret(),
+		EventTypes: []string{"test.event"},
+	})
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+	next := webhooks.Attempt{
+		ID:             uuid.NewString(),
+		WebhookID:      uuid.NewString(),
+		Config:         cfg,
+		Payload:        string(payload),
+		StatusCode:     500,
+		RetryAttempt:   2,
+		Status:         webhooks.StatusAttemptToRetry,
+		NextRetryAfter: time.Now().UTC().Add(time.Minute),
+	}
+
+	err = store.InsertOneAttemptAndUpdateAttemptsStatus(ctx, next, next.WebhookID, webhooks.StatusAttemptFailed)
+	require.ErrorIs(t, err, storage.ErrWebhookIDNotFound)
+
+	count, err := db.NewSelect().Model((*webhooks.Attempt)(nil)).
+		Where("id = ?", next.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, count, "insert must be rolled back when the status update fails")
 }
 
 func TestRecoverStaleRetryingAttempts(t *testing.T) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -38,4 +38,8 @@ type Store interface {
 	// config no longer exists as 'failed', so they stop polluting the retry queue
 	// forever. Returns the number of rows updated.
 	FailOrphanedAttempts(ctx context.Context) (int64, error)
+	// CountAttemptsToRetry returns the number of attempts currently queued for
+	// retry ('to retry'). Used as the retry-queue-depth gauge — the leading
+	// indicator of a retry storm.
+	CountAttemptsToRetry(ctx context.Context) (int64, error)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	UpdateOneConfigActivation(ctx context.Context, id string, active bool) (webhooks.Config, error)
 	UpdateOneConfigSecret(ctx context.Context, id, secret string) (webhooks.Config, error)
 	FindAttemptsToRetryByWebhookID(ctx context.Context, webhookID string) ([]webhooks.Attempt, error)
+	FindFirstAttemptCreatedAtByWebhookID(ctx context.Context, webhookID string) (time.Time, error)
 	FindWebhookIDsToRetry(ctx context.Context, limit int) (webhookIDs []string, err error)
 	RecoverStaleRetryingAttempts(ctx context.Context, staleDuration time.Duration) error
 	UpdateAttemptsStatus(ctx context.Context, webhookID string, status string) ([]webhooks.Attempt, error)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -27,21 +27,21 @@ type Store interface {
 	RecoverStaleRetryingAttempts(ctx context.Context, staleDuration time.Duration) error
 	UpdateAttemptsStatus(ctx context.Context, webhookID string, status string) ([]webhooks.Attempt, error)
 	InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error
+	InsertOneAttemptAndUpdateAttemptsStatus(ctx context.Context, att webhooks.Attempt, webhookID string, status string) error
 	Close(ctx context.Context) error
 	UpdateOneConfig(ctx context.Context, id string, cfg webhooks.ConfigUser) error
 
 	// PurgeFinishedAttempts deletes terminal attempts older than the given
-	// retentions (success vs failed), in batches of at most batchSize rows, and
-	// returns the total number of rows deleted. A retention <= 0 disables purging
-	// for that status.
+	// retentions (success vs failed), up to batchSize rows per status and run.
+	// A retention <= 0 disables purging for that status.
 	PurgeFinishedAttempts(ctx context.Context, successOlderThan, failedOlderThan time.Duration, batchSize int) (int64, error)
-	// FailUnclaimableAttempts marks pending attempts ('to retry'/'retrying')
-	// whose config no longer exists or is inactive as 'failed', so they stop
-	// polluting the retry queue forever. Rows are updated in batches of at most
-	// batchSize. Returns the number of rows updated.
-	FailUnclaimableAttempts(ctx context.Context, batchSize int) (int64, error)
-	// CountAttemptsToRetry returns the number of attempts currently queued for
-	// retry ('to retry'). Used as the retry-queue-depth gauge — the leading
+	// FailUnclaimableAttempts marks pending attempts whose config no longer exists
+	// or is inactive as 'failed'. 'to retry' rows are failed immediately; 'retrying'
+	// rows are failed only after retryingStaleDuration so in-flight workers are not
+	// raced by retention. At most batchSize rows are updated per run.
+	FailUnclaimableAttempts(ctx context.Context, batchSize int, retryingStaleDuration time.Duration) (int64, error)
+	// CountAttemptsToRetry returns the capped number of attempts currently queued
+	// for retry ('to retry'). Used as the retry-queue-depth gauge — the leading
 	// indicator of a retry storm.
 	CountAttemptsToRetry(ctx context.Context) (int64, error)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -34,11 +34,11 @@ type Store interface {
 	// returns the total number of rows deleted. A retention <= 0 disables purging
 	// for that status.
 	PurgeFinishedAttempts(ctx context.Context, successOlderThan, failedOlderThan time.Duration, batchSize int) (int64, error)
-	// FailOrphanedAttempts marks pending attempts ('to retry'/'retrying') whose
-	// config no longer exists as 'failed', so they stop polluting the retry queue
-	// forever. Rows are updated in batches of at most batchSize. Returns the
-	// number of rows updated.
-	FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, error)
+	// FailUnclaimableAttempts marks pending attempts ('to retry'/'retrying')
+	// whose config no longer exists or is inactive as 'failed', so they stop
+	// polluting the retry queue forever. Rows are updated in batches of at most
+	// batchSize. Returns the number of rows updated.
+	FailUnclaimableAttempts(ctx context.Context, batchSize int) (int64, error)
 	// CountAttemptsToRetry returns the number of attempts currently queued for
 	// retry ('to retry'). Used as the retry-queue-depth gauge — the leading
 	// indicator of a retry storm.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -28,4 +28,14 @@ type Store interface {
 	InsertOneAttempt(ctx context.Context, att webhooks.Attempt) error
 	Close(ctx context.Context) error
 	UpdateOneConfig(ctx context.Context, id string, cfg webhooks.ConfigUser) error
+
+	// PurgeFinishedAttempts deletes terminal attempts older than the given
+	// retentions (success vs failed), in batches of at most batchSize rows, and
+	// returns the total number of rows deleted. A retention <= 0 disables purging
+	// for that status.
+	PurgeFinishedAttempts(ctx context.Context, successOlderThan, failedOlderThan time.Duration, batchSize int) (int64, error)
+	// FailOrphanedAttempts marks pending attempts ('to retry'/'retrying') whose
+	// config no longer exists as 'failed', so they stop polluting the retry queue
+	// forever. Returns the number of rows updated.
+	FailOrphanedAttempts(ctx context.Context) (int64, error)
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -36,8 +36,9 @@ type Store interface {
 	PurgeFinishedAttempts(ctx context.Context, successOlderThan, failedOlderThan time.Duration, batchSize int) (int64, error)
 	// FailOrphanedAttempts marks pending attempts ('to retry'/'retrying') whose
 	// config no longer exists as 'failed', so they stop polluting the retry queue
-	// forever. Returns the number of rows updated.
-	FailOrphanedAttempts(ctx context.Context) (int64, error)
+	// forever. Rows are updated in batches of at most batchSize. Returns the
+	// number of rows updated.
+	FailOrphanedAttempts(ctx context.Context, batchSize int) (int64, error)
 	// CountAttemptsToRetry returns the number of attempts currently queued for
 	// retry ('to retry'). Used as the retry-queue-depth gauge — the leading
 	// indicator of a retry storm.

--- a/pkg/worker/message_ack_test.go
+++ b/pkg/worker/message_ack_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/formancehq/go-libs/v2/publish"
+	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -25,7 +25,7 @@ import (
 
 var Tracer = otel.Tracer("listener")
 
-func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy, retryBatchSize int, debug bool, topics []string) fx.Option {
+func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webhooks.BackoffPolicy, retryBatchSize int, debug bool, topics []string, retention RetentionConfig) fx.Option {
 	var options []fx.Option
 
 	options = append(options, fx.Invoke(func(r *message.Router, subscriber message.Subscriber, store storage.Store, httpClient *http.Client) {
@@ -38,6 +38,15 @@ func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webh
 		NewRetrier,
 	))
 	options = append(options, fx.Invoke(run))
+
+	if retention.Enabled() {
+		options = append(options,
+			fx.Provide(func(store storage.Store) *Retention {
+				return NewRetention(store, retention)
+			}),
+			fx.Invoke(runRetention),
+		)
+	}
 
 	return fx.Options(options...)
 }
@@ -59,6 +68,26 @@ func run(lc fx.Lifecycle, w *Retrier) {
 
 			if err := w.store.Close(ctx); err != nil {
 				return fmt.Errorf("storage.Store.Close: %w", err)
+			}
+			return nil
+		},
+	})
+}
+
+func runRetention(lc fx.Lifecycle, r *Retention) {
+	ctx, cancel := context.WithCancel(context.Background())
+	lc.Append(fx.Hook{
+		OnStart: func(startCtx context.Context) error {
+			logging.FromContext(startCtx).Debugf("starting retention...")
+			go r.Run(ctx)
+			return nil
+		},
+		OnStop: func(stopCtx context.Context) error {
+			logging.FromContext(stopCtx).Debugf("stopping retention...")
+			cancel()
+			select {
+			case <-r.doneCh:
+			case <-stopCtx.Done():
 			}
 			return nil
 		},

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -38,6 +39,7 @@ func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webh
 		NewRetrier,
 	))
 	options = append(options, fx.Invoke(run))
+	options = append(options, fx.Invoke(registerQueueDepthMetric))
 
 	if retention.Enabled() {
 		options = append(options,
@@ -72,6 +74,26 @@ func run(lc fx.Lifecycle, w *Retrier) {
 			return nil
 		},
 	})
+}
+
+// registerQueueDepthMetric registers the retry-queue-depth observable gauge. It
+// binds to the global meter provider (a no-op when metrics are disabled), so the
+// callback only queries the store when a real collector is scraping.
+func registerQueueDepthMetric(store storage.Store) error {
+	meter := otel.GetMeterProvider().Meter("webhooks")
+	_, err := meter.Int64ObservableGauge(
+		"webhooks_retry_queue_depth",
+		metric.WithDescription("Number of attempts currently queued for retry ('to retry')"),
+		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
+			n, err := store.CountAttemptsToRetry(ctx)
+			if err != nil {
+				return err
+			}
+			o.Observe(n)
+			return nil
+		}),
+	)
+	return err
 }
 
 func runRetention(lc fx.Lifecycle, r *Retention) {

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -93,7 +93,7 @@ func registerQueueDepthMetric(store storage.Store) error {
 	meter := otel.GetMeterProvider().Meter("webhooks")
 	_, err := meter.Int64ObservableGauge(
 		"webhooks_retry_queue_depth",
-		metric.WithDescription("Number of attempts currently queued for retry ('to retry')"),
+		metric.WithDescription("Number of attempts currently queued for retry ('to retry'), capped at 1000000"),
 		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
 			n, err := store.CountAttemptsToRetry(ctx)
 			if err != nil {

--- a/pkg/worker/module.go
+++ b/pkg/worker/module.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/formancehq/go-libs/v2/otlp/otlpmetrics"
 	"github.com/formancehq/go-libs/v2/publish"
 	webhooks "github.com/formancehq/webhooks/pkg"
 	"github.com/formancehq/webhooks/pkg/storage"
@@ -39,7 +40,16 @@ func StartModule(cmd *cobra.Command, retriesCron time.Duration, retryPolicy webh
 		NewRetrier,
 	))
 	options = append(options, fx.Invoke(run))
-	options = append(options, fx.Invoke(registerQueueDepthMetric))
+
+	// Only register the DB-backed queue-depth gauge when metrics are actually
+	// exported: the otlpmetrics module installs a periodic reader even with the
+	// no-op exporter, which would otherwise run the COUNT query every collect
+	// interval for a value nobody reads.
+	exporter, _ := cmd.Flags().GetString(otlpmetrics.OtelMetricsExporterFlag)
+	keepInMemory, _ := cmd.Flags().GetBool(otlpmetrics.OtelMetricsKeepInMemoryFlag)
+	if exporter != "" || keepInMemory {
+		options = append(options, fx.Invoke(registerQueueDepthMetric))
+	}
 
 	if retention.Enabled() {
 		options = append(options,
@@ -68,9 +78,9 @@ func run(lc fx.Lifecycle, w *Retrier) {
 			logging.FromContext(ctx).Debugf("stopping worker...")
 			w.Stop(ctx)
 
-			if err := w.store.Close(ctx); err != nil {
-				return fmt.Errorf("storage.Store.Close: %w", err)
-			}
+			// Note: the database connection is owned and closed by the
+			// bunconnect fx module; closing it here would shut it down before
+			// later-stopping modules (e.g. the metrics flush) are done with it.
 			return nil
 		},
 	})

--- a/pkg/worker/retention.go
+++ b/pkg/worker/retention.go
@@ -1,0 +1,84 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/formancehq/go-libs/v2/logging"
+	"github.com/formancehq/webhooks/pkg/storage"
+)
+
+const defaultRetentionBatchSize = 5000
+
+// RetentionConfig configures the periodic cleanup of the attempts table.
+// Without it, the table grows without bound: success rows are kept forever and
+// attempts of deleted configs loop in the retry queue. In production this drove
+// the table to 100+ GB and dominated cross-AZ RDS replication cost.
+type RetentionConfig struct {
+	// Period between cleanup runs.
+	Period time.Duration
+	// SuccessDelay retains 'success' attempts for this long (<=0 disables).
+	SuccessDelay time.Duration
+	// FailedDelay retains 'failed' attempts for this long (<=0 disables).
+	FailedDelay time.Duration
+	// BatchSize bounds the number of rows deleted per statement.
+	BatchSize int
+}
+
+// Enabled reports whether any retention action is configured.
+func (c RetentionConfig) Enabled() bool {
+	return c.SuccessDelay > 0 || c.FailedDelay > 0
+}
+
+// Retention periodically purges old terminal attempts and reclaims attempts
+// whose config has been deleted.
+type Retention struct {
+	store  storage.Store
+	cfg    RetentionConfig
+	doneCh chan struct{}
+}
+
+func NewRetention(store storage.Store, cfg RetentionConfig) *Retention {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultRetentionBatchSize
+	}
+	return &Retention{
+		store:  store,
+		cfg:    cfg,
+		doneCh: make(chan struct{}),
+	}
+}
+
+func (r *Retention) Run(ctx context.Context) {
+	defer close(r.doneCh)
+
+	ticker := time.NewTicker(r.cfg.Period)
+	defer ticker.Stop()
+
+	// Run once on startup so a freshly deployed worker reclaims any standing
+	// backlog without waiting a full period.
+	r.runOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.runOnce(ctx)
+		}
+	}
+}
+
+func (r *Retention) runOnce(ctx context.Context) {
+	if n, err := r.store.FailOrphanedAttempts(ctx); err != nil {
+		logging.FromContext(ctx).Errorf("retention: failing orphaned attempts: %s", err)
+	} else if n > 0 {
+		logging.FromContext(ctx).Infof("retention: marked %d orphaned attempts as failed", n)
+	}
+
+	if n, err := r.store.PurgeFinishedAttempts(ctx, r.cfg.SuccessDelay, r.cfg.FailedDelay, r.cfg.BatchSize); err != nil {
+		logging.FromContext(ctx).Errorf("retention: purging finished attempts: %s", err)
+	} else if n > 0 {
+		logging.FromContext(ctx).Infof("retention: purged %d finished attempts", n)
+	}
+}

--- a/pkg/worker/retention.go
+++ b/pkg/worker/retention.go
@@ -24,7 +24,7 @@ type RetentionConfig struct {
 	SuccessDelay time.Duration
 	// FailedDelay retains 'failed' attempts for this long (<=0 disables).
 	FailedDelay time.Duration
-	// BatchSize bounds the number of rows deleted per statement.
+	// BatchSize bounds the number of rows touched per cleanup statement and run.
 	BatchSize int
 }
 
@@ -79,7 +79,7 @@ func (r *Retention) Run(ctx context.Context) {
 }
 
 func (r *Retention) runOnce(ctx context.Context) {
-	if n, err := r.store.FailUnclaimableAttempts(ctx, r.cfg.BatchSize); err != nil {
+	if n, err := r.store.FailUnclaimableAttempts(ctx, r.cfg.BatchSize, staleRetryingAttemptAge); err != nil {
 		logging.FromContext(ctx).Errorf("retention: failing unclaimable attempts: %s", err)
 	} else if n > 0 {
 		logging.FromContext(ctx).Infof("retention: marked %d unclaimable attempts as failed", n)

--- a/pkg/worker/retention.go
+++ b/pkg/worker/retention.go
@@ -15,8 +15,8 @@ const (
 
 // RetentionConfig configures the periodic cleanup of the attempts table.
 // Without it, the table grows without bound: success rows are kept forever and
-// attempts of deleted configs loop in the retry queue. In production this drove
-// the table to 100+ GB and dominated cross-AZ RDS replication cost.
+// attempts of deleted or inactive configs stay in the retry queue. In production
+// this drove the table to 100+ GB and dominated cross-AZ RDS replication cost.
 type RetentionConfig struct {
 	// Period between cleanup runs.
 	Period time.Duration
@@ -34,7 +34,7 @@ func (c RetentionConfig) Enabled() bool {
 }
 
 // Retention periodically purges old terminal attempts and reclaims attempts
-// whose config has been deleted.
+// whose config has been deleted or deactivated.
 type Retention struct {
 	store  storage.Store
 	cfg    RetentionConfig
@@ -77,10 +77,10 @@ func (r *Retention) Run(ctx context.Context) {
 }
 
 func (r *Retention) runOnce(ctx context.Context) {
-	if n, err := r.store.FailOrphanedAttempts(ctx, r.cfg.BatchSize); err != nil {
-		logging.FromContext(ctx).Errorf("retention: failing orphaned attempts: %s", err)
+	if n, err := r.store.FailUnclaimableAttempts(ctx, r.cfg.BatchSize); err != nil {
+		logging.FromContext(ctx).Errorf("retention: failing unclaimable attempts: %s", err)
 	} else if n > 0 {
-		logging.FromContext(ctx).Infof("retention: marked %d orphaned attempts as failed", n)
+		logging.FromContext(ctx).Infof("retention: marked %d unclaimable attempts as failed", n)
 	}
 
 	if n, err := r.store.PurgeFinishedAttempts(ctx, r.cfg.SuccessDelay, r.cfg.FailedDelay, r.cfg.BatchSize); err != nil {

--- a/pkg/worker/retention.go
+++ b/pkg/worker/retention.go
@@ -8,7 +8,10 @@ import (
 	"github.com/formancehq/webhooks/pkg/storage"
 )
 
-const defaultRetentionBatchSize = 5000
+const (
+	defaultRetentionBatchSize = 5000
+	defaultRetentionPeriod    = time.Hour
+)
 
 // RetentionConfig configures the periodic cleanup of the attempts table.
 // Without it, the table grows without bound: success rows are kept forever and
@@ -42,6 +45,10 @@ func NewRetention(store storage.Store, cfg RetentionConfig) *Retention {
 	if cfg.BatchSize <= 0 {
 		cfg.BatchSize = defaultRetentionBatchSize
 	}
+	// Guard against a zero/negative period: time.NewTicker panics on <= 0.
+	if cfg.Period <= 0 {
+		cfg.Period = defaultRetentionPeriod
+	}
 	return &Retention{
 		store:  store,
 		cfg:    cfg,
@@ -70,7 +77,7 @@ func (r *Retention) Run(ctx context.Context) {
 }
 
 func (r *Retention) runOnce(ctx context.Context) {
-	if n, err := r.store.FailOrphanedAttempts(ctx); err != nil {
+	if n, err := r.store.FailOrphanedAttempts(ctx, r.cfg.BatchSize); err != nil {
 		logging.FromContext(ctx).Errorf("retention: failing orphaned attempts: %s", err)
 	} else if n > 0 {
 		logging.FromContext(ctx).Infof("retention: marked %d orphaned attempts as failed", n)

--- a/pkg/worker/retention.go
+++ b/pkg/worker/retention.go
@@ -28,9 +28,11 @@ type RetentionConfig struct {
 	BatchSize int
 }
 
-// Enabled reports whether any retention action is configured.
+// Enabled reports whether any retention action is configured. The runner must
+// also stay enabled when terminal purging is disabled, because it reclaims
+// retrying/to-retry attempts whose config was deleted or deactivated.
 func (c RetentionConfig) Enabled() bool {
-	return c.SuccessDelay > 0 || c.FailedDelay > 0
+	return c.Period > 0 || c.SuccessDelay > 0 || c.FailedDelay > 0
 }
 
 // Retention periodically purges old terminal attempts and reclaims attempts

--- a/pkg/worker/retention_test.go
+++ b/pkg/worker/retention_test.go
@@ -1,0 +1,17 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetentionConfigEnabled(t *testing.T) {
+	require.False(t, RetentionConfig{}.Enabled())
+
+	require.True(t, RetentionConfig{Period: time.Hour}.Enabled(),
+		"the runner must start to reclaim deleted/inactive config attempts even when terminal purging is disabled")
+	require.True(t, RetentionConfig{SuccessDelay: time.Hour}.Enabled())
+	require.True(t, RetentionConfig{FailedDelay: time.Hour}.Enabled())
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -140,6 +140,18 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 	}
 
 	newAttemptNb := atts[0].RetryAttempt + 1
+	if limiter, ok := w.retryPolicy.(webhooks.RetryAttemptLimiter); ok {
+		if err := limiter.CanRetryAttempt(newAttemptNb); err != nil {
+			logging.FromContext(ctx).Debugf("retry cap reached for webhook %s at attempt %d: %s",
+				webhookID, newAttemptNb, err)
+			if _, updateErr := w.store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptFailed); updateErr != nil {
+				logging.FromContext(ctx).Errorf("marking retry capped attempts failed for webhook %s: %s",
+					webhookID, updateErr)
+			}
+			return
+		}
+	}
+
 	attempt, err := webhooks.MakeAttempt(ctx, w.httpClient, w.retryPolicy, uuid.NewString(),
 		webhookID, newAttemptNb, atts[0].Config, ev.IdempotencyKey, []byte(atts[0].Payload), false)
 	if err != nil {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -79,7 +79,10 @@ func (w *Retrier) Stop(ctx context.Context) {
 
 var errNoAttemptsFound = errors.New("attemptRetries: no attempts found")
 
-const staleRecoveryInterval = time.Minute
+const (
+	staleRecoveryInterval   = time.Minute
+	staleRetryingAttemptAge = 5 * time.Minute
+)
 
 func (w *Retrier) attemptRetries(ctx context.Context) {
 	lastRecovery := time.Time{}
@@ -91,7 +94,7 @@ func (w *Retrier) attemptRetries(ctx context.Context) {
 		default:
 			// Recover attempts stuck in "retrying" state from crashed workers (at most once per minute)
 			if time.Since(lastRecovery) >= staleRecoveryInterval {
-				if err := w.store.RecoverStaleRetryingAttempts(ctx, 5*time.Minute); err != nil {
+				if err := w.store.RecoverStaleRetryingAttempts(ctx, staleRetryingAttemptAge); err != nil {
 					logging.FromContext(ctx).Errorf("recovering stale retrying attempts: %s", err)
 				}
 				lastRecovery = time.Now()
@@ -139,6 +142,15 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 		return
 	}
 
+	if err := limitRetryWindowBeforeAttempt(w.retryPolicy, firstAttemptAt); err != nil {
+		logging.FromContext(ctx).Debugf("retry window elapsed for webhook %s: %s", webhookID, err)
+		if _, updateErr := w.store.UpdateAttemptsStatus(ctx, webhookID, webhooks.StatusAttemptFailed); updateErr != nil {
+			logging.FromContext(ctx).Errorf("marking retry window elapsed attempts failed for webhook %s: %s",
+				webhookID, updateErr)
+		}
+		return
+	}
+
 	var ev publish.EventMessage
 	if err := json.Unmarshal([]byte(atts[0].Payload), &ev); err != nil {
 		logging.FromContext(ctx).Errorf("unmarshalling payload for webhook %s: %s", webhookID, err)
@@ -166,19 +178,24 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 		return
 	}
 
-	if err := w.store.InsertOneAttempt(ctx, attempt); err != nil {
-		logging.FromContext(ctx).Errorf("inserting attempt for webhook %s: %s", webhookID, err)
-		return
-	}
-
 	claimedStatus := attempt.Status
 	if claimedStatus == webhooks.StatusAttemptToRetry {
 		claimedStatus = webhooks.StatusAttemptFailed
 	}
-	if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, claimedStatus); err != nil {
+	if err := w.store.InsertOneAttemptAndUpdateAttemptsStatus(ctx, attempt, webhookID, claimedStatus); err != nil {
 		if errors.Is(err, storage.ErrAttemptsNotModified) {
 			return
 		}
-		logging.FromContext(ctx).Errorf("updating attempts status for webhook %s: %s", webhookID, err)
+		logging.FromContext(ctx).Errorf("inserting attempt and updating attempts status for webhook %s: %s", webhookID, err)
 	}
+}
+
+func limitRetryWindowBeforeAttempt(retryPolicy webhooks.BackoffPolicy, firstAttemptAt time.Time) error {
+	if firstAttemptAt.IsZero() {
+		return nil
+	}
+	if limiter, ok := retryPolicy.(webhooks.RetryWindowLimiter); ok {
+		return limiter.LimitRetryWindow(time.Since(firstAttemptAt))
+	}
+	return nil
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -133,6 +133,12 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 		return
 	}
 
+	firstAttemptAt, err := w.store.FindFirstAttemptCreatedAtByWebhookID(ctx, webhookID)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("finding first attempt for webhook %s: %s", webhookID, err)
+		return
+	}
+
 	var ev publish.EventMessage
 	if err := json.Unmarshal([]byte(atts[0].Payload), &ev); err != nil {
 		logging.FromContext(ctx).Errorf("unmarshalling payload for webhook %s: %s", webhookID, err)
@@ -153,7 +159,8 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 	}
 
 	attempt, err := webhooks.MakeAttempt(ctx, w.httpClient, w.retryPolicy, uuid.NewString(),
-		webhookID, newAttemptNb, atts[0].Config, ev.IdempotencyKey, []byte(atts[0].Payload), false)
+		webhookID, newAttemptNb, atts[0].Config, ev.IdempotencyKey, []byte(atts[0].Payload), false,
+		webhooks.WithFirstAttemptAt(firstAttemptAt))
 	if err != nil {
 		logging.FromContext(ctx).Errorf("making attempt for webhook %s: %s", webhookID, err)
 		return
@@ -164,7 +171,11 @@ func (w *Retrier) processWebhookRetry(ctx context.Context, webhookID string) {
 		return
 	}
 
-	if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, attempt.Status); err != nil {
+	claimedStatus := attempt.Status
+	if claimedStatus == webhooks.StatusAttemptToRetry {
+		claimedStatus = webhooks.StatusAttemptFailed
+	}
+	if _, err := w.store.UpdateAttemptsStatus(ctx, webhookID, claimedStatus); err != nil {
 		if errors.Is(err, storage.ErrAttemptsNotModified) {
 			return
 		}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -86,7 +86,9 @@ func (m *mockStore) UpdateOneConfig(_ context.Context, _ string, _ webhooks.Conf
 func (m *mockStore) PurgeFinishedAttempts(_ context.Context, _, _ time.Duration, _ int) (int64, error) {
 	return 0, nil
 }
-func (m *mockStore) FailOrphanedAttempts(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockStore) FailOrphanedAttempts(_ context.Context, _ int) (int64, error) {
+	return 0, nil
+}
 func (m *mockStore) CountAttemptsToRetry(_ context.Context) (int64, error) { return 0, nil }
 func (m *mockStore) Close(_ context.Context) error                         { return nil }
 

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -83,7 +83,11 @@ func (m *mockStore) UpdateOneConfigSecret(_ context.Context, _, _ string) (webho
 func (m *mockStore) UpdateOneConfig(_ context.Context, _ string, _ webhooks.ConfigUser) error {
 	return nil
 }
-func (m *mockStore) Close(_ context.Context) error { return nil }
+func (m *mockStore) PurgeFinishedAttempts(_ context.Context, _, _ time.Duration, _ int) (int64, error) {
+	return 0, nil
+}
+func (m *mockStore) FailOrphanedAttempts(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockStore) Close(_ context.Context) error                         { return nil }
 
 func TestProcessWebhookRetrySuccess(t *testing.T) {
 	// HTTP server that returns 200

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -119,7 +119,7 @@ func TestProcessWebhookRetrySuccess(t *testing.T) {
 		},
 	})
 
-	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
 	require.NoError(t, err)
 
 	retrier.processWebhookRetry(context.Background(), webhookID)
@@ -166,7 +166,7 @@ func TestProcessWebhookRetryFailure(t *testing.T) {
 		},
 	})
 
-	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
 	require.NoError(t, err)
 
 	retrier.processWebhookRetry(context.Background(), webhookID)
@@ -228,7 +228,7 @@ func TestPoolProcessesBatchInParallel(t *testing.T) {
 
 	store := newMockStore(webhookIDs, attempts)
 
-	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
 	require.NoError(t, err)
 
 	// Manually claim and process (simulating one tick)
@@ -260,7 +260,7 @@ func TestProcessWebhookRetryNoAttempts(t *testing.T) {
 
 	store := newMockStore(nil, map[string][]webhooks.Attempt{})
 
-	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
 	require.NoError(t, err)
 
 	// Should not panic or make HTTP calls
@@ -300,7 +300,7 @@ func TestProcessWebhookRetryBadPayload(t *testing.T) {
 		},
 	})
 
-	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour), 10)
+	retrier, err := NewRetrier(store, server.Client(), time.Second, backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
 	require.NoError(t, err)
 
 	// Should not panic, should log error and return

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -87,6 +87,7 @@ func (m *mockStore) PurgeFinishedAttempts(_ context.Context, _, _ time.Duration,
 	return 0, nil
 }
 func (m *mockStore) FailOrphanedAttempts(_ context.Context) (int64, error) { return 0, nil }
+func (m *mockStore) CountAttemptsToRetry(_ context.Context) (int64, error) { return 0, nil }
 func (m *mockStore) Close(_ context.Context) error                         { return nil }
 
 func TestProcessWebhookRetrySuccess(t *testing.T) {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -48,6 +48,21 @@ func (m *mockStore) FindAttemptsToRetryByWebhookID(_ context.Context, webhookID 
 	return m.attempts[webhookID], nil
 }
 
+func (m *mockStore) FindFirstAttemptCreatedAtByWebhookID(_ context.Context, webhookID string) (time.Time, error) {
+	atts := m.attempts[webhookID]
+	if len(atts) == 0 {
+		return time.Time{}, nil
+	}
+
+	first := atts[0].CreatedAt
+	for _, att := range atts[1:] {
+		if first.IsZero() || (!att.CreatedAt.IsZero() && att.CreatedAt.Before(first)) {
+			first = att.CreatedAt
+		}
+	}
+	return first, nil
+}
+
 func (m *mockStore) InsertOneAttempt(_ context.Context, att webhooks.Attempt) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -181,6 +196,8 @@ func TestProcessWebhookRetryFailure(t *testing.T) {
 	// A new attempt should have been inserted with "to retry" status
 	require.Len(t, store.inserted, 1)
 	require.Equal(t, webhooks.StatusAttemptToRetry, store.inserted[0].Status)
+	require.Equal(t, webhooks.StatusAttemptFailed, store.updated[webhookID],
+		"claimed attempts must be terminalized so only the newly inserted row remains queued")
 }
 
 func TestProcessWebhookRetryDoesNotCallEndpointAfterMaxAttempts(t *testing.T) {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -70,6 +70,14 @@ func (m *mockStore) InsertOneAttempt(_ context.Context, att webhooks.Attempt) er
 	return nil
 }
 
+func (m *mockStore) InsertOneAttemptAndUpdateAttemptsStatus(_ context.Context, att webhooks.Attempt, webhookID string, status string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inserted = append(m.inserted, att)
+	m.updated[webhookID] = status
+	return nil
+}
+
 func (m *mockStore) UpdateAttemptsStatus(_ context.Context, webhookID string, status string) ([]webhooks.Attempt, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -101,7 +109,7 @@ func (m *mockStore) UpdateOneConfig(_ context.Context, _ string, _ webhooks.Conf
 func (m *mockStore) PurgeFinishedAttempts(_ context.Context, _, _ time.Duration, _ int) (int64, error) {
 	return 0, nil
 }
-func (m *mockStore) FailUnclaimableAttempts(_ context.Context, _ int) (int64, error) {
+func (m *mockStore) FailUnclaimableAttempts(_ context.Context, _ int, _ time.Duration) (int64, error) {
 	return 0, nil
 }
 func (m *mockStore) CountAttemptsToRetry(_ context.Context) (int64, error) { return 0, nil }
@@ -242,6 +250,53 @@ func TestProcessWebhookRetryDoesNotCallEndpointAfterMaxAttempts(t *testing.T) {
 	retrier.processWebhookRetry(context.Background(), webhookID)
 
 	require.Zero(t, hits.Load(), "retry cap must be checked before the outbound HTTP call")
+	require.Empty(t, store.inserted, "no synthetic attempt should be inserted when no HTTP attempt was made")
+	require.Equal(t, webhooks.StatusAttemptFailed, store.updated[webhookID])
+}
+
+func TestProcessWebhookRetryDoesNotCallEndpointAfterAbortWindow(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 1,
+				Status:       webhooks.StatusAttemptRetrying,
+				CreatedAt:    time.Now().UTC().Add(-2 * time.Hour),
+			},
+		},
+	})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second,
+		backoff.NewExponential(time.Second, time.Minute, time.Hour, 0), 10)
+	require.NoError(t, err)
+
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	require.Zero(t, hits.Load(), "retry window must be checked before the outbound HTTP call")
 	require.Empty(t, store.inserted, "no synthetic attempt should be inserted when no HTTP attempt was made")
 	require.Equal(t, webhooks.StatusAttemptFailed, store.updated[webhookID])
 }

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -86,7 +86,7 @@ func (m *mockStore) UpdateOneConfig(_ context.Context, _ string, _ webhooks.Conf
 func (m *mockStore) PurgeFinishedAttempts(_ context.Context, _, _ time.Duration, _ int) (int64, error) {
 	return 0, nil
 }
-func (m *mockStore) FailOrphanedAttempts(_ context.Context, _ int) (int64, error) {
+func (m *mockStore) FailUnclaimableAttempts(_ context.Context, _ int) (int64, error) {
 	return 0, nil
 }
 func (m *mockStore) CountAttemptsToRetry(_ context.Context) (int64, error) { return 0, nil }
@@ -181,6 +181,52 @@ func TestProcessWebhookRetryFailure(t *testing.T) {
 	// A new attempt should have been inserted with "to retry" status
 	require.Len(t, store.inserted, 1)
 	require.Equal(t, webhooks.StatusAttemptToRetry, store.inserted[0].Status)
+}
+
+func TestProcessWebhookRetryDoesNotCallEndpointAfterMaxAttempts(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	webhookID := "webhook-1"
+	payload, _ := json.Marshal(map[string]string{"type": "test.event"})
+
+	cfg := webhooks.Config{
+		ConfigUser: webhooks.ConfigUser{
+			Endpoint:   server.URL,
+			Secret:     webhooks.NewSecret(),
+			EventTypes: []string{"test.event"},
+		},
+		ID:     "config-1",
+		Active: true,
+	}
+
+	store := newMockStore(nil, map[string][]webhooks.Attempt{
+		webhookID: {
+			{
+				ID:           "att-1",
+				WebhookID:    webhookID,
+				Config:       cfg,
+				Payload:      string(payload),
+				StatusCode:   500,
+				RetryAttempt: 0,
+				Status:       webhooks.StatusAttemptRetrying,
+			},
+		},
+	})
+
+	retrier, err := NewRetrier(store, server.Client(), time.Second,
+		backoff.NewExponential(time.Second, time.Minute, time.Hour, 1), 10)
+	require.NoError(t, err)
+
+	retrier.processWebhookRetry(context.Background(), webhookID)
+
+	require.Zero(t, hits.Load(), "retry cap must be checked before the outbound HTTP call")
+	require.Empty(t, store.inserted, "no synthetic attempt should be inserted when no HTTP attempt was made")
+	require.Equal(t, webhooks.StatusAttemptFailed, store.updated[webhookID])
 }
 
 func TestPoolProcessesBatchInParallel(t *testing.T) {

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -38,12 +38,12 @@ var _ = Context("Retries", func() {
 			}
 		})
 	)
-	Context("the endpoint only returning errors", func() {
+	Context("the endpoint only returning transient errors", func() {
 		var httpServer *httptest.Server
 		BeforeEach(func() {
 			httpServer = httptest.NewServer(http.HandlerFunc(
 				func(w http.ResponseWriter, _ *http.Request) {
-					http.Error(w, "error", http.StatusNotFound)
+					http.Error(w, "error", http.StatusInternalServerError)
 				}))
 			DeferCleanup(httpServer.Close)
 
@@ -90,6 +90,47 @@ var _ = Context("Retries", func() {
 
 			Eventually(getNumPendingRetryAttempts).WithArguments(db).
 				WithTimeout(10 * time.Second).
+				Should(Equal(0))
+		})
+	})
+	Context("the endpoint returning a permanent client error", func() {
+		var httpServer *httptest.Server
+		BeforeEach(func() {
+			httpServer = httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "error", http.StatusNotFound)
+				}))
+			DeferCleanup(httpServer.Close)
+
+			cfg := components.ConfigUser{
+				Endpoint: httpServer.URL,
+				EventTypes: []string{
+					"foo",
+				},
+			}
+			_, err := srv.GetValue().Client().Webhooks.V1.InsertConfig(
+				ctx,
+				cfg,
+			)
+			Expect(err).To(BeNil())
+		})
+		It("should fail immediately without scheduling any retry", func() {
+			db, err := bunconnect.OpenSQLDB(logging.TestingContext(), db.GetValue().ConnectionOptions())
+			Expect(err).ToNot(HaveOccurred())
+
+			err = natsServer.
+				GetValue().
+				Client(GinkgoT()).
+				Publish("foo", []byte(`{"type":"foo"}`))
+			Expect(err).To(BeNil())
+
+			Eventually(getNumFailedAttempts).WithArguments(db).
+				WithTimeout(5 * time.Second).
+				Should(BeNumerically(">=", 1))
+
+			// A permanent 4xx must never enter the retry queue
+			Consistently(getNumPendingRetryAttempts).WithArguments(db).
+				WithTimeout(3 * time.Second).
 				Should(Equal(0))
 		})
 	})

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -89,7 +89,7 @@ var _ = Context("Retries", func() {
 				WithTimeout(12 * time.Second).
 				Should(BeNumerically(">=", 3))
 
-			Eventually(getNumPendingRetryAttempts).WithArguments(db).
+			Eventually(getNumPendingRetryAttemptsForEndpoint).WithArguments(db, httpServer.URL).
 				WithTimeout(10 * time.Second).
 				Should(Equal(0))
 		})
@@ -186,12 +186,12 @@ var _ = Context("Retries", func() {
 				Publish("foo", []byte(`{"type":"foo"}`))
 			Expect(err).To(BeNil())
 
-			Eventually(getNumFailedAttempts).WithArguments(db).
+			Eventually(getNumEndpointAttemptsByStatus).WithArguments(db, httpServer.URL, webhooks.StatusAttemptFailed).
 				WithTimeout(5 * time.Second).
 				Should(BeNumerically(">=", 1))
 
 			// A permanent 4xx must never enter the retry queue
-			Consistently(getNumPendingRetryAttempts).WithArguments(db).
+			Consistently(getNumPendingRetryAttemptsForEndpoint).WithArguments(db, httpServer.URL).
 				WithTimeout(3 * time.Second).
 				Should(Equal(0))
 		})

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -229,21 +229,6 @@ func getNumEndpointAttemptsByStatus(db *bun.DB, endpoint, status string) (int, e
 	return count, err
 }
 
-func getNumPendingRetryAttempts(db *bun.DB) (int, error) {
-	var results []webhooks.Attempt
-	err := db.NewSelect().Model(&results).
-		Where("status IN (?)", bun.List([]string{
-			webhooks.StatusAttemptToRetry,
-			webhooks.StatusAttemptRetrying,
-		})).
-		Scan(logging.TestingContext())
-	if err != nil {
-		return 0, err
-	}
-
-	return len(results), nil
-}
-
 func getNumPendingRetryAttemptsForEndpoint(db *bun.DB, endpoint string) (int, error) {
 	count, err := db.NewSelect().Model((*webhooks.Attempt)(nil)).
 		Where("config->>'endpoint' = ?", endpoint).

--- a/test/e2e/trigger_test.go
+++ b/test/e2e/trigger_test.go
@@ -3,15 +3,16 @@
 package test_suite
 
 import (
-	"github.com/davecgh/go-spew/spew"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"time"
+
 	"github.com/formancehq/go-libs/v2/bun/bunconnect"
 	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/formancehq/go-libs/v2/testing/platform/pgtesting"
 	"github.com/formancehq/webhooks/pkg/client/models/components"
 	"github.com/formancehq/webhooks/pkg/testserver"
-	"net/http"
-	"net/http/httptest"
-	"time"
 
 	webhooks "github.com/formancehq/webhooks/pkg"
 	. "github.com/onsi/ginkgo/v2"
@@ -85,12 +86,73 @@ var _ = Context("Retries", func() {
 				Should(BeNumerically(">", 0))
 
 			Eventually(getNumFailedAttempts).WithArguments(db).
-				WithTimeout(5 * time.Second).
+				WithTimeout(12 * time.Second).
 				Should(BeNumerically(">=", 3))
 
 			Eventually(getNumPendingRetryAttempts).WithArguments(db).
 				WithTimeout(10 * time.Second).
 				Should(Equal(0))
+		})
+	})
+	Context("the endpoint recovering after a transient error", func() {
+		var (
+			httpServer *httptest.Server
+			recovered  atomic.Bool
+			calls      atomic.Int32
+		)
+		BeforeEach(func() {
+			recovered.Store(false)
+			calls.Store(0)
+			httpServer = httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					calls.Add(1)
+					if !recovered.Load() {
+						http.Error(w, "temporary error", http.StatusInternalServerError)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				}))
+			DeferCleanup(httpServer.Close)
+
+			cfg := components.ConfigUser{
+				Endpoint: httpServer.URL,
+				EventTypes: []string{
+					"foo",
+				},
+			}
+			_, err := srv.GetValue().Client().Webhooks.V1.InsertConfig(
+				ctx,
+				cfg,
+			)
+			Expect(err).To(BeNil())
+		})
+		It("should deliver queued messages once the endpoint returns 200", func() {
+			db, err := bunconnect.OpenSQLDB(logging.TestingContext(), db.GetValue().ConnectionOptions())
+			Expect(err).ToNot(HaveOccurred())
+
+			err = natsServer.
+				GetValue().
+				Client(GinkgoT()).
+				Publish("foo", []byte(`{"type":"foo"}`))
+			Expect(err).To(BeNil())
+
+			Eventually(getNumEndpointAttemptsByStatus).WithArguments(db, httpServer.URL, webhooks.StatusAttemptToRetry).
+				WithTimeout(5 * time.Second).
+				Should(BeNumerically(">", 0))
+
+			recovered.Store(true)
+
+			Eventually(getNumEndpointAttemptsByStatus).WithArguments(db, httpServer.URL, webhooks.StatusAttemptSuccess).
+				WithTimeout(10 * time.Second).
+				Should(BeNumerically(">", 0))
+
+			Eventually(getNumPendingRetryAttemptsForEndpoint).WithArguments(db, httpServer.URL).
+				WithTimeout(5 * time.Second).
+				Should(Equal(0))
+
+			Eventually(func() int32 {
+				return calls.Load()
+			}).WithTimeout(5 * time.Second).Should(BeNumerically(">=", 2))
 		})
 	})
 	Context("the endpoint returning a permanent client error", func() {
@@ -144,7 +206,6 @@ func getNumAttemptsToRetry(db *bun.DB) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	spew.Dump(results)
 	return len(results), nil
 }
 
@@ -160,6 +221,14 @@ func getNumFailedAttempts(db *bun.DB) (int, error) {
 	return len(results), nil
 }
 
+func getNumEndpointAttemptsByStatus(db *bun.DB, endpoint, status string) (int, error) {
+	count, err := db.NewSelect().Model((*webhooks.Attempt)(nil)).
+		Where("config->>'endpoint' = ?", endpoint).
+		Where("status = ?", status).
+		Count(logging.TestingContext())
+	return count, err
+}
+
 func getNumPendingRetryAttempts(db *bun.DB) (int, error) {
 	var results []webhooks.Attempt
 	err := db.NewSelect().Model(&results).
@@ -173,4 +242,15 @@ func getNumPendingRetryAttempts(db *bun.DB) (int, error) {
 	}
 
 	return len(results), nil
+}
+
+func getNumPendingRetryAttemptsForEndpoint(db *bun.DB, endpoint string) (int, error) {
+	count, err := db.NewSelect().Model((*webhooks.Attempt)(nil)).
+		Where("config->>'endpoint' = ?", endpoint).
+		Where("status IN (?)", bun.List([]string{
+			webhooks.StatusAttemptToRetry,
+			webhooks.StatusAttemptRetrying,
+		})).
+		Count(logging.TestingContext())
+	return count, err
 }


### PR DESCRIPTION
## Summary

- Classify permanent 4xx as terminal failures and honor bounded Retry-After for retryable responses.
- Bound retry storms with max attempts, a coherent abort window, atomic retry state transitions, and retention cleanup for orphaned attempts.
- Add retry queue observability, retention indexes, and tests covering recovery after endpoint success, retry caps, abort-window preflight, retention, and migrations.

## Behavior changes

- Default `--max-attempts` is 15. With the default exponential backoff this usually exhausts retries after about 9h03.
- Default `--abort-after` is now 10h, so the elapsed-time window is coherent with the attempt cap and remains the backstop for Retry-After, worker downtime, and backlog delays.
- Retention now processes bounded batches per run instead of draining the full backlog in one tick.

## Validation

- `go test ./...`
- `go test -tags it ./test/e2e`
- `nix develop --impure --command just pre-commit`