### PR TITLE
fix: make audit middleware opt-in

### DIFF
--- a/cmd/flag/flags.go
+++ b/cmd/flag/flags.go
@@ -12,6 +12,8 @@ const (
 	Listen   = "listen"
 	Worker   = "worker"
 
+	AuditEnabled = "audit-enabled"
+
 	RetryPeriod     = "retry-period"
 	RetryBatchSize  = "retry-batch-size"
 	AbortAfter      = "abort-after"
@@ -53,6 +55,7 @@ func Init(flagSet *pflag.FlagSet) {
 	flagSet.Duration(RetryPeriod, DefaultRetryPeriod, "worker retry period")
 	flagSet.Int(RetryBatchSize, DefaultRetryBatchSize, "number of webhook IDs to claim per retry tick")
 	flagSet.Bool(Worker, false, "Enable worker on server")
+	flagSet.Bool(AuditEnabled, false, "Enable HTTP audit events publishing")
 
 	flagSet.StringSlice(KafkaTopics, []string{DefaultKafkaTopic}, "Kafka topics")
 

--- a/cmd/flag/flags_test.go
+++ b/cmd/flag/flags_test.go
@@ -1,0 +1,28 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditEnabledDefaultsToFalse(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	Init(flags)
+
+	auditEnabled, err := flags.GetBool(AuditEnabled)
+	require.NoError(t, err)
+	require.False(t, auditEnabled)
+}
+
+func TestAuditEnabledCanBeEnabled(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	Init(flags)
+
+	require.NoError(t, flags.Parse([]string{"--" + AuditEnabled}))
+
+	auditEnabled, err := flags.GetBool(AuditEnabled)
+	require.NoError(t, err)
+	require.True(t, auditEnabled)
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -50,6 +50,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 	}
 
 	listen, _ := cmd.Flags().GetString(flag.Listen)
+	auditEnabled, _ := cmd.Flags().GetBool(flag.AuditEnabled)
 	options := []fx.Option{
 		fx.Provide(func() server.ServiceInfo {
 			return server.ServiceInfo{
@@ -63,7 +64,7 @@ func serve(cmd *cobra.Command, _ []string) error {
 		// gauges) before the database connection is closed.
 		otlpmetrics.FXModuleFromFlags(cmd),
 		innerotlp.HttpClientModule(),
-		server.FXModuleFromFlags(cmd, listen, service.IsDebug(cmd)),
+		server.FXModuleFromFlags(cmd, listen, service.IsDebug(cmd), auditEnabled),
 		licence.FXModuleFromFlags(cmd, ServiceName),
 	}
 	isWorker, _ := cmd.Flags().GetBool(flag.Worker)

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -41,6 +41,7 @@ func newServerHandler(
 	authenticator auth.Authenticator,
 	publisher message.Publisher,
 	debug bool,
+	auditEnabled bool,
 ) http.Handler {
 	h := &serverHandler{
 		Mux:        chi.NewRouter(),
@@ -48,7 +49,9 @@ func newServerHandler(
 		httpClient: httpClient,
 	}
 
-	h.Use(httpaudit.Middleware(publisher, "audit-events", "webhooks", nil))
+	if auditEnabled {
+		h.Use(httpaudit.Middleware(publisher, "audit-events", "webhooks", nil))
+	}
 	h.Use(func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/module.go
+++ b/pkg/server/module.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/fx"
 )
 
-func FXModuleFromFlags(cmd *cobra.Command, addr string, debug bool) fx.Option {
+func FXModuleFromFlags(cmd *cobra.Command, addr string, debug bool, auditEnabled bool) fx.Option {
 	var options []fx.Option
 
 	options = append(options,
@@ -34,7 +34,7 @@ func FXModuleFromFlags(cmd *cobra.Command, addr string, debug bool) fx.Option {
 			authenticator auth.Authenticator,
 			publisher message.Publisher,
 		) http.Handler {
-			return newServerHandler(store, httpClient, logger, info, authenticator, publisher, debug)
+			return newServerHandler(store, httpClient, logger, info, authenticator, publisher, debug, auditEnabled)
 		},
 	), fx.Invoke(func(lc fx.Lifecycle, handler http.Handler) {
 		lc.Append(httpserver.NewHook(handler, httpserver.WithAddress(addr)))


### PR DESCRIPTION
## What

Make the HTTP audit middleware opt-in behind a new `--audit-enabled` flag, defaulting to `false`.

## Why

`v2.4.0` mounted the audit middleware unconditionally. In environments where NATS publishing is enabled but audit is not configured, every HTTP request tried to publish to `audit-events`, which caused repeated logs like:

```text
failed to publish audit message: sending message failed: nats: no response from stream
```

This also let Watermill/NATS auto-provision attempt to create/use the audit stream even when audit should be disabled.

## Impact

Default behavior no longer publishes audit events or touches the `audit-events` stream. Deployments that want audit events can explicitly pass `--audit-enabled`.

## Validation

```text
go test ./...
```