### PR TITLE
fix: update CODEOWNERS team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for the entire repository
-* @formancehq/backend
+* @formancehq/transactions


### PR DESCRIPTION
## Summary

- replace the removed `@formancehq/backend` CODEOWNER with `@formancehq/transactions`
- keep the existing repository-wide ownership rule unchanged

## Rationale

Webhooks delivers Ledger and Payments platform events. The Transactions team is active and includes the repository's recent maintainers and reviewers, making it the closest current owner for this backend service.

## Validation

- verified `@formancehq/transactions` exists and has active members
- verified only `.github/CODEOWNERS` changed
- `git diff --check`