### PR TITLE
fix(worker): provide debug dependency to HTTP handler

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -69,10 +69,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 		innerotlp.HttpClientModule(),
 		licence.FXModuleFromFlags(cmd, ServiceName),
 		postgres.NewModule(*connectionOptions, service.IsDebug(cmd)),
-		fx.Provide(worker.NewWorkerHandler),
-		fx.Invoke(func(lc fx.Lifecycle, h http.Handler) {
-			lc.Append(httpserver.NewHook(h, httpserver.WithAddress(listen)))
-		}),
+		workerHTTPServerModule(cmd, listen),
 		otlp.FXModuleFromFlags(cmd),
 		otlptraces.FXModuleFromFlags(cmd),
 		otlpmetrics.FXModuleFromFlags(cmd),
@@ -90,6 +87,19 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 			retention,
 		),
 	).Run(cmd)
+}
+
+func workerHTTPServerModule(cmd *cobra.Command, listen string) fx.Option {
+	debug := service.IsDebug(cmd)
+
+	return fx.Options(
+		fx.Provide(func() http.Handler {
+			return worker.NewWorkerHandler(debug)
+		}),
+		fx.Invoke(func(lc fx.Lifecycle, h http.Handler) {
+			lc.Append(httpserver.NewHook(h, httpserver.WithAddress(listen)))
+		}),
+	)
 }
 
 func retentionConfigFromFlags(cmd *cobra.Command) worker.RetentionConfig {

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestWorkerHTTPServerModuleProvidesHandlerDependencies(t *testing.T) {
+	cmd := newWorkerCommand()
+
+	app := fx.New(
+		workerHTTPServerModule(cmd, "127.0.0.1:0"),
+		fx.NopLogger,
+	)
+
+	require.NoError(t, app.Err())
+}


### PR DESCRIPTION
## What changed

- bind the Cobra-resolved debug setting when constructing the standalone worker HTTP handler
- add an Fx graph regression test for the worker HTTP server module

## Why

The standalone `webhooks worker` process registered `worker.NewWorkerHandler` directly with Fx even though the constructor requires a `bool`. No boolean provider existed in that graph, so workers exited during startup with `missing type: bool`.

Operator `v3.13.1` exposes this previously unused path by running Webhooks `v2.5.x` workers in a dedicated Deployment. The API process remains healthy, but the worker Deployment enters `CrashLoopBackOff`.

Capturing `service.IsDebug(cmd)` in the provider closure supplies the intended configuration without adding an ambiguous global `bool` dependency to the Fx container.

## Impact

Standalone Webhooks workers can build their Fx graph and start their health server, allowing the dedicated worker Deployments introduced by the Operator to become ready.

## Validation

- `go test ./cmd`
- `go test -race -covermode=atomic -coverprofile coverage.txt -tags it ./...`
- `git diff --check`
