### PR TITLE
fix(worker): provide publisher dependencies

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -49,9 +49,18 @@ func newWorkerCommand() *cobra.Command {
 }
 
 func runWorker(cmd *cobra.Command, _ []string) error {
-	connectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd)
+	options, err := workerServiceOptions(cmd)
 	if err != nil {
 		return err
+	}
+
+	return service.New(cmd.OutOrStdout(), options...).Run(cmd)
+}
+
+func workerServiceOptions(cmd *cobra.Command) ([]fx.Option, error) {
+	connectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd)
+	if err != nil {
+		return nil, err
 	}
 
 	retryPeriod, _ := cmd.Flags().GetDuration(flag.RetryPeriod)
@@ -64,10 +73,10 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 	listen, _ := cmd.Flags().GetString(flag.Listen)
 	retention := retentionConfigFromFlags(cmd)
 
-	return service.New(
-		cmd.OutOrStdout(),
+	return []fx.Option{
 		innerotlp.HttpClientModule(),
 		licence.FXModuleFromFlags(cmd, ServiceName),
+		publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
 		postgres.NewModule(*connectionOptions, service.IsDebug(cmd)),
 		workerHTTPServerModule(cmd, listen),
 		otlp.FXModuleFromFlags(cmd),
@@ -86,7 +95,7 @@ func runWorker(cmd *cobra.Command, _ []string) error {
 			topics,
 			retention,
 		),
-	).Run(cmd)
+	}, nil
 }
 
 func workerHTTPServerModule(cmd *cobra.Command, listen string) fx.Option {

--- a/cmd/worker_test.go
+++ b/cmd/worker_test.go
@@ -3,17 +3,20 @@ package cmd
 import (
 	"testing"
 
+	"github.com/formancehq/go-libs/v2/logging"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 )
 
-func TestWorkerHTTPServerModuleProvidesHandlerDependencies(t *testing.T) {
+func TestWorkerServiceOptionsProvideAllDependencies(t *testing.T) {
 	cmd := newWorkerCommand()
+	require.NoError(t, cmd.Flags().Set("postgres-uri", "postgresql://localhost/webhooks"))
+	options, err := workerServiceOptions(cmd)
+	require.NoError(t, err)
 
-	app := fx.New(
-		workerHTTPServerModule(cmd, "127.0.0.1:0"),
-		fx.NopLogger,
+	options = append(options,
+		fx.Supply(fx.Annotate(logging.Testing(), fx.As(new(logging.Logger)))),
 	)
 
-	require.NoError(t, app.Err())
+	require.NoError(t, fx.ValidateApp(options...))
 }


### PR DESCRIPTION
## What changed

- install the publisher Fx module in the standalone worker service graph
- extract the complete worker service options for dependency validation
- expand the regression test to validate the full worker graph

## Why

After Webhooks `v2.5.2` fixed the worker HTTP handler dependency, standalone workers advanced further and then exited with:

```text
missing types: *message.Router; message.Subscriber
```

The worker command registered publisher flags but did not install `publish.FXModuleFromFlags`, which provides the Watermill router and subscriber consumed by `worker.StartModule`.

The previous regression test only validated the HTTP submodule. Validating all worker service options now detects both the original missing `bool` and any missing broker dependencies.

## Validation

- `go test ./cmd`
- `go test -race -covermode=atomic -coverprofile coverage.txt -tags it ./...`
- `go vet ./...`
- `git diff --check`
