### PR TITLE
docs(openapi): describe the schema fields in the spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -421,45 +421,48 @@ components:
   schemas:
     DeliveryStatus:
       type: string
+      description: Current state of a delivery in its retry lifecycle
       enum: [pending, delivering, succeeded, failed, cancelled]
     Delivery:
       type: object
+      description: An event queued for delivery to a webhook endpoint, tracking its retry state
       required: [id, eventID, configID, eventType, status, attemptCount, replayGeneration, createdAt, updatedAt]
       properties:
-        id: {type: string, format: uuid}
-        eventID: {type: string}
-        idempotencyKey: {type: string}
-        configID: {type: string, format: uuid}
-        eventType: {type: string}
+        id: {type: string, format: uuid, description: "Unique identifier of the delivery"}
+        eventID: {type: string, description: "Identifier of the event being delivered"}
+        idempotencyKey: {type: string, description: "Key sent with the request so the receiver can deduplicate retries of the same delivery"}
+        configID: {type: string, format: uuid, description: "Identifier of the webhook configuration this delivery targets"}
+        eventType: {type: string, description: "Type of the event being delivered"}
         payload: {type: string, description: Present only on delivery detail responses.}
         status: {$ref: '#/components/schemas/DeliveryStatus'}
-        attemptCount: {type: integer}
-        replayGeneration: {type: integer}
-        cycleStartedAt: {type: string, format: date-time}
-        nextAttemptAt: {type: string, format: date-time}
-        claimedAt: {type: string, format: date-time}
-        lastAttemptAt: {type: string, format: date-time}
-        lastStatusCode: {type: integer}
-        lastError: {type: string}
-        createdAt: {type: string, format: date-time}
-        updatedAt: {type: string, format: date-time}
+        attemptCount: {type: integer, description: "Number of attempts made in the current retry cycle"}
+        replayGeneration: {type: integer, description: "Incremented each time the delivery is replayed, grouping attempts into retry cycles"}
+        cycleStartedAt: {type: string, format: date-time, description: "When the current retry cycle began. Cleared when the delivery is replayed"}
+        nextAttemptAt: {type: string, format: date-time, description: "When the next delivery attempt is scheduled"}
+        claimedAt: {type: string, format: date-time, description: "When a worker claimed this delivery for the attempt in flight. Cleared when the delivery is replayed"}
+        lastAttemptAt: {type: string, format: date-time, description: "When the most recent attempt was made"}
+        lastStatusCode: {type: integer, description: "HTTP status code returned by the most recent attempt"}
+        lastError: {type: string, description: "Error reported by the most recent attempt"}
+        createdAt: {type: string, format: date-time, description: "When the delivery was created"}
+        updatedAt: {type: string, format: date-time, description: "When the delivery was last modified"}
     DeliveryAttempt:
       type: object
       required: [id, deliveryID, attemptNumber, replayGeneration, endpoint, outcome, statusCode, createdAt]
       properties:
-        id: {type: string, format: uuid}
-        deliveryID: {type: string, format: uuid}
-        attemptNumber: {type: integer}
-        replayGeneration: {type: integer}
-        endpoint: {type: string, format: uri}
+        id: {type: string, format: uuid, description: "Unique identifier of the attempt"}
+        deliveryID: {type: string, format: uuid, description: "Identifier of the delivery this attempt belongs to"}
+        attemptNumber: {type: integer, description: "Position of this attempt within its retry cycle"}
+        replayGeneration: {type: integer, description: "Retry cycle this attempt belongs to"}
+        endpoint: {type: string, format: uri, description: "URL the attempt was sent to"}
         outcome:
           type: string
+          description: How the attempt ended. A retryable failure is retried, a permanent failure is not
           enum: [succeeded, retryable_failure, permanent_failure]
-        statusCode: {type: integer}
-        error: {type: string}
-        durationMillis: {type: integer, format: int64}
-        responseExcerpt: {type: string}
-        createdAt: {type: string, format: date-time}
+        statusCode: {type: integer, description: "HTTP status code returned by the endpoint"}
+        error: {type: string, description: "Error reported by the attempt, when it did not succeed"}
+        durationMillis: {type: integer, format: int64, description: "How long the attempt took, in milliseconds"}
+        responseExcerpt: {type: string, description: "Truncated body returned by the endpoint, kept for troubleshooting"}
+        createdAt: {type: string, format: date-time, description: "When the attempt was made"}
     DeliveryResponse:
       type: object
       required: [data]
@@ -471,6 +474,7 @@ components:
       properties:
         cursor:
           type: object
+          description: Paginated cursor wrapping the list of deliveries
           required: [hasMore, data]
           properties:
             pageSize: {type: integer}
@@ -485,6 +489,7 @@ components:
       properties:
         cursor:
           type: object
+          description: Paginated cursor wrapping the list of delivery attempts
           required: [hasMore, data]
           properties:
             pageSize: {type: integer}
@@ -497,29 +502,32 @@ components:
       type: object
       required: [createdAtFrom]
       properties:
-        createdAtFrom: {type: string, format: date-time}
-        createdAtTo: {type: string, format: date-time}
+        createdAtFrom: {type: string, format: date-time, description: "Replay deliveries created at or after this time"}
+        createdAtTo: {type: string, format: date-time, description: "Replay deliveries created before this time. Defaults to now when omitted"}
         statuses:
           type: array
           items:
             type: string
             enum: [failed, pending]
           default: [failed, pending]
+          description: Restrict the replay to deliveries in these statuses
         configIds:
           type: array
+          description: Restrict the replay to deliveries targeting these webhook configurations
           items: {type: string, format: uuid}
-        cursor: {type: string}
-        pageSize: {type: integer, minimum: 1, maximum: 1000, default: 1000}
+        cursor: {type: string, description: "Pagination cursor from a previous replay response, used to continue a large replay"}
+        pageSize: {type: integer, minimum: 1, maximum: 1000, default: 1000, description: "Maximum number of deliveries to process in this call"}
     ReplayDeliveriesResult:
       type: object
+      description: Outcome of a bulk replay, counting the deliveries it moved
       required: [replayed, expedited, skipped, hasMore, createdAtTo]
       properties:
-        replayed: {type: integer}
-        expedited: {type: integer}
-        skipped: {type: integer}
-        hasMore: {type: boolean}
-        nextCursor: {type: string}
-        createdAtTo: {type: string, format: date-time}
+        replayed: {type: integer, description: "Number of failed deliveries moved back to pending and scheduled for a new retry cycle"}
+        expedited: {type: integer, description: "Number of already-pending deliveries whose next attempt was brought forward to now"}
+        skipped: {type: integer, description: "Number of candidates left untouched, because their status changed before the replay applied"}
+        hasMore: {type: boolean, description: "Whether further deliveries match and can be processed with the returned cursor"}
+        nextCursor: {type: string, description: "Cursor to pass to the next replay call to continue where this one stopped"}
+        createdAtTo: {type: string, format: date-time, description: "Upper time bound actually applied, echoed so a paginated replay stays on a fixed window"}
     ReplayDeliveriesResponse:
       type: object
       required: [data]
@@ -533,12 +541,15 @@ components:
       properties:
         endpoint:
           type: string
+          description: URL events are delivered to
           example: https://example.com
         secret:
           type: string
+          description: Secret used to sign delivery payloads. Generated automatically when omitted
           example: V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3
         eventTypes:
           type: array
+          description: Types of event that trigger a delivery to this endpoint
           items:
             type: string
             example: TYPE1
@@ -551,6 +562,7 @@ components:
         - cursor
       properties:
         cursor:
+          description: Paginated cursor wrapping the list of configurations
           allOf:
             - $ref: '#/components/schemas/Cursor'
             - properties:
@@ -569,9 +581,11 @@ components:
       properties:
         hasMore:
           type: boolean
+          description: Whether further pages are available
           example: false
         data:
           type: array
+          description: The configurations on this page
           items:
             $ref: '#/components/schemas/WebhooksConfig'
     ConfigResponse:
@@ -583,18 +597,23 @@ components:
           $ref: '#/components/schemas/WebhooksConfig'
     WebhooksConfig:
       type: object
+      description: A webhook endpoint together with the event types it subscribes to
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the configuration
         endpoint:
           type: string
+          description: URL events are delivered to
           example: https://example.com
         secret:
           type: string
+          description: Secret used to sign delivery payloads, letting the receiver verify their authenticity
           example: V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3
         eventTypes:
           type: array
+          description: Types of event that trigger a delivery to this endpoint
           items:
             type: string
             example: TYPE1
@@ -603,13 +622,16 @@ components:
             - TYPE2
         active:
           type: boolean
+          description: Whether the configuration is active. Deactivated configurations receive no deliveries
           example: true
         createdAt:
           type: string
           format: date-time
+          description: When the configuration was created
         updatedAt:
           type: string
           format: date-time
+          description: When the configuration was last modified
       required:
         - id
         - endpoint
@@ -623,6 +645,7 @@ components:
       properties:
         secret:
           type: string
+          description: The new signing secret. Generated automatically when omitted
           example: V0bivxRWveaoz08afqjU6Ko/jwO0Cb+3
       required:
         - secret
@@ -635,36 +658,46 @@ components:
           $ref: '#/components/schemas/Attempt'
     Attempt:
       type: object
+      description: A single delivery attempt made against a webhook endpoint
       properties:
         id:
           type: string
           format: uuid
+          description: Unique identifier of the attempt
         webhookID:
           type: string
           format: uuid
+          description: Identifier of the webhook this attempt belongs to
         createdAt:
           type: string
           format: date-time
+          description: When the attempt was created
         updatedAt:
           type: string
           format: date-time
+          description: When the attempt was last modified
         config:
           $ref: '#/components/schemas/WebhooksConfig'
         payload:
           type: string
+          description: The event body sent to the endpoint
           example: '{"data":"test"}'
         statusCode:
           type: integer
+          description: HTTP status code returned by the endpoint
           example: 200
         retryAttempt:
           type: integer
+          description: Position of this attempt in the retry sequence
           example: 1
         status:
           type: string
+          description: Current status of the attempt
           example: success
         nextRetryAfter:
           type: string
           format: date-time
+          description: When the next retry is scheduled, absent once the attempt is settled
       required:
         - id
         - webhookID
@@ -685,13 +718,16 @@ components:
           $ref: '#/components/schemas/ErrorsEnum'
         errorMessage:
           type: string
+          description: Human-readable description of the error
           example: '[VALIDATION] invalid ''cursor'' query param'
         details:
           type: string
+          description: Optional link carrying additional context about the error
           example: >-
             https://play.numscript.org/?payload=eyJlcnJvciI6ImFjY291bnQgaGFkIGluc3VmZmljaWVudCBmdW5kcyJ9
     ErrorsEnum:
       type: string
+      description: Machine-readable error code identifying the failure
       enum:
         - INTERNAL
         - VALIDATION


### PR DESCRIPTION
## Why

The Webhooks OpenAPI spec declares its schemas without saying what any of the fields mean. That is worst on the delivery machinery: `replayGeneration`, `cycleStartedAt`, `attemptCount`, `idempotencyKey` and `DeliveryStatus` describe a retry lifecycle that an integrator has no way to infer from the field names alone.

## What

Adds `description` across the 18 schemas — `Delivery`, `DeliveryStatus`, `DeliveryAttempt`, `Attempt`, `WebhooksConfig`, `ConfigUser`, `Cursor`, the replay request/response types and the cursor responses.

Some inline-mapping entries (`id: {type: string, format: uuid}`) grew a `description` key, which is why those lines show as modified rather than added — the type information is unchanged.

No structural changes: no fields added or removed, no types or required-ness touched, so generated clients keep the same shape and only pick up doc comments.

Part of a sweep doing the same across the module specs.